### PR TITLE
Added New label-related commands

### DIFF
--- a/src/model/ModelInterface.h
+++ b/src/model/ModelInterface.h
@@ -33,6 +33,8 @@ public:
     virtual ActionResult Delete(const Core::TaskID &, bool deleteChildren) = 0;
     virtual ActionResult Validate(const Core::TaskID &) const = 0;
     virtual ActionResult AddLabel(const Core::TaskID &, const std::string &label) = 0;
+    virtual ActionResult ClearLabel(const Core::TaskID &, const std::string &label) = 0;
+    virtual ActionResult ClearLabels(const Core::TaskID &) = 0;
 
 public:
     virtual void Replace(const std::vector<Core::TaskEntity> &) = 0;

--- a/src/model/TaskManager.cpp
+++ b/src/model/TaskManager.cpp
@@ -147,6 +147,27 @@ ActionResult TaskManager::AddLabel(const Core::TaskID &id, const std::string &la
     return {ActionResult::Status::SUCCESS, id};
 }
 
+ActionResult TaskManager::ClearLabel(const Core::TaskID &id, const std::string &label) {
+    try {
+        auto labels = tasks_.at(id).first.mutable_labels();
+        auto it = find(labels->begin(), labels->end(), label);
+        if (it != labels->end())
+            tasks_.at(id).first.mutable_labels()->erase(it);
+    } catch (const std::out_of_range &) {
+        return {ActionResult::Status::ID_NOT_FOUND, id};
+    }
+    return {ActionResult::Status::SUCCESS, id};
+}
+
+ActionResult TaskManager::ClearLabels(const Core::TaskID &id) {
+    try {
+        tasks_.at(id).first.clear_labels();
+    } catch (const std::out_of_range &) {
+        return {ActionResult::Status::ID_NOT_FOUND, id};
+    }
+    return {ActionResult::Status::SUCCESS, id};
+}
+
 void TaskManager::Replace(const std::vector<Core::TaskEntity> &vec) {
     tasks_.clear();
     Core::TaskID max_id;

--- a/src/model/TaskManager.h
+++ b/src/model/TaskManager.h
@@ -33,6 +33,8 @@ public:
     ActionResult Delete(const Core::TaskID &id, bool deleteChildren) override;
     ActionResult Validate(const Core::TaskID &id) const override;
     ActionResult AddLabel(const Core::TaskID &, const std::string &) override;
+    ActionResult ClearLabel(const Core::TaskID &, const std::string &) override;
+    ActionResult ClearLabels(const Core::TaskID &) override;
 
 public:
     void Replace(const std::vector<Core::TaskEntity> &) override;

--- a/src/model/help.txt
+++ b/src/model/help.txt
@@ -23,6 +23,11 @@
     label <id>          prompts the user to enter a label to be assigned to the task with ID
                         <id>.
 
+    unlabel <id>        prompts the user to enter a label to be removed from the task with ID
+                        <id>.
+
+    UNLABEL <id>        clears all labels for the task with ID <id>.
+
     show [<label>]      when used with no argument, displays all tasks and their subtasks in a
          [<id>]         hierarchy, along with their IDs. When a label is given, shows only
                         (sub)tasks with this label. When an ID is given, shows that task and

--- a/src/ui/Factory.cpp
+++ b/src/ui/Factory.cpp
@@ -17,6 +17,9 @@
 #include "ui/steps/DeleteStep.h"
 #include "ui/steps/ConfirmDeleteStep.h"
 #include "ui/steps/LabelStep.h"
+#include "ui/steps/ClearAllLabelsStep.h"
+#include "ui/steps/ClearLabelStep.h"
+#include "ui/steps/ShowAllLabelsStep.h"
 #include "Machine.h"
 
 Factory::Factory() :
@@ -69,6 +72,12 @@ std::shared_ptr<Step> Factory::createStep(const std::string &command) {
         return lazyInitStep(Factory::State::CONFIRMDELETE);
     } else if (command == "label") {
         return lazyInitStep(Factory::State::LABEL);
+    } else if (command == "unlabel") {
+        return lazyInitStep(Factory::State::UNLABEL);
+    } else if (command == "UNLABEL") {
+        return lazyInitStep(Factory::State::UNLABELALL);
+    } else if (command == "labels") {
+        return lazyInitStep(Factory::State::LABELS);
     } else if (command == "save") {
         return lazyInitStep(Factory::State::HOME);
     } else if (command == "load") {
@@ -111,7 +120,13 @@ std::shared_ptr<Step> Factory::getNewStep(const State &s) {
         case State::CONFIRMDELETE:
             return std::shared_ptr<ConfirmDeleteStep>{new ConfirmDeleteStep(reader(), printer())};
         case State::LABEL:
-            return std::shared_ptr<LabelStep>{new LabelStep(reader(), printer())};
+            return std::shared_ptr<Step>{new LabelStep(reader(), printer())};
+        case State::UNLABEL:
+            return std::shared_ptr<Step>{new ClearLabelStep(reader(), printer())};
+        case State::LABELS:
+            return std::shared_ptr<Step>{new ShowAllLabelsStep(reader(), printer())};
+        case State::UNLABELALL:
+            return std::shared_ptr<Step>{new ClearAllLabelsStep(reader(), printer())};
     }
 }
 

--- a/src/ui/Factory.h
+++ b/src/ui/Factory.h
@@ -34,7 +34,10 @@ public:
         UNCOMPLETE,
         DELETE,
         CONFIRMDELETE,
-        LABEL
+        LABEL,
+        UNLABEL,
+        UNLABELALL,
+        LABELS
     };
 
 public:

--- a/src/ui/StepSwitcher.cpp
+++ b/src/ui/StepSwitcher.cpp
@@ -57,3 +57,15 @@ std::shared_ptr<Step> StepSwitcher::nextStep(const ConfirmDeleteStep &, const st
 std::shared_ptr<Step> StepSwitcher::nextStep(const LabelStep &, const std::shared_ptr<Factory> &factory) {
     return factory->lazyInitStep(Factory::State::HOME);
 }
+
+std::shared_ptr<Step> StepSwitcher::nextStep(const ClearLabelStep &, const std::shared_ptr<Factory> &factory) {
+    return factory->lazyInitStep(Factory::State::HOME);
+}
+
+std::shared_ptr<Step> StepSwitcher::nextStep(const ShowAllLabelsStep &, const std::shared_ptr<Factory> &factory) {
+    return factory->lazyInitStep(Factory::State::HOME);
+}
+
+std::shared_ptr<Step> StepSwitcher::nextStep(const ClearAllLabelsStep &, const std::shared_ptr<Factory> &factory) {
+    return factory->lazyInitStep(Factory::State::HOME);
+}

--- a/src/ui/StepSwitcher.h
+++ b/src/ui/StepSwitcher.h
@@ -23,6 +23,9 @@ class DeleteStep;
 class DeleteStep;
 class ConfirmDeleteStep;
 class LabelStep;
+class ClearLabelStep;
+class ClearAllLabelsStep;
+class ShowAllLabelsStep;
 
 class StepSwitcher {
 public:
@@ -39,6 +42,9 @@ public:
     static std::shared_ptr<Step> nextStep(const DeleteStep &, const std::shared_ptr<Factory> &);
     static std::shared_ptr<Step> nextStep(const ConfirmDeleteStep &, const std::shared_ptr<Factory> &);
     static std::shared_ptr<Step> nextStep(const LabelStep &, const std::shared_ptr<Factory> &);
+    static std::shared_ptr<Step> nextStep(const ClearLabelStep &, const std::shared_ptr<Factory> &);
+    static std::shared_ptr<Step> nextStep(const ClearAllLabelsStep &, const std::shared_ptr<Factory> &);
+    static std::shared_ptr<Step> nextStep(const ShowAllLabelsStep &, const std::shared_ptr<Factory> &);
 };
 
 #endif //TASKMANAGER_SRC_UI_STEPSWITCHER_H_

--- a/src/ui/actions/ClearAllLabelsOfTaskAction.cpp
+++ b/src/ui/actions/ClearAllLabelsOfTaskAction.cpp
@@ -1,0 +1,13 @@
+//
+// Created by Anton O. on 1/17/22.
+//
+
+#include "ClearAllLabelsOfTaskAction.h"
+#include "ui/Context.h"
+
+ClearAllLabelsOfTaskAction::ClearAllLabelsOfTaskAction(const Core::TaskID &id) : id_{id}{
+}
+
+ActionResult ClearAllLabelsOfTaskAction::execute(const std::shared_ptr<ModelInterface> &model) {
+    return model->ClearLabels(id_);
+}

--- a/src/ui/actions/ClearAllLabelsOfTaskAction.h
+++ b/src/ui/actions/ClearAllLabelsOfTaskAction.h
@@ -1,0 +1,22 @@
+//
+// Created by Anton O. on 1/17/22.
+//
+
+#ifndef TASKMANAGER_SRC_UI_ACTIONS_CLEARALLLABELSOFTASKSACTION_H_
+#define TASKMANAGER_SRC_UI_ACTIONS_CLEARALLLABELSOFTASKSACTION_H_
+
+#include "Action.h"
+
+class ClearAllLabelsOfTaskAction : public Action {
+public:
+    ClearAllLabelsOfTaskAction(const Core::TaskID &);
+
+public:
+    ActionResult execute(const std::shared_ptr<ModelInterface> &) override;
+
+private:
+    Core::TaskID id_;
+};
+
+
+#endif //TASKMANAGER_SRC_UI_ACTIONS_CLEARALLLABELSOFTASKSACTION_H_

--- a/src/ui/actions/ClearAllLabelsOfTaskAction.h
+++ b/src/ui/actions/ClearAllLabelsOfTaskAction.h
@@ -9,7 +9,7 @@
 
 class ClearAllLabelsOfTaskAction : public Action {
 public:
-    ClearAllLabelsOfTaskAction(const Core::TaskID &);
+    explicit ClearAllLabelsOfTaskAction(const Core::TaskID &);
 
 public:
     ActionResult execute(const std::shared_ptr<ModelInterface> &) override;

--- a/src/ui/actions/ClearLabelOfTaskAction.cpp
+++ b/src/ui/actions/ClearLabelOfTaskAction.cpp
@@ -1,0 +1,14 @@
+//
+// Created by Anton O. on 1/17/22.
+//
+
+#include "ClearLabelOfTaskAction.h"
+#include "ui/Context.h"
+
+ClearLabelOfTaskAction::ClearLabelOfTaskAction(const Core::TaskID &id, const std::string &label) :
+        id_{id}, label_{label} {
+}
+
+ActionResult ClearLabelOfTaskAction::execute(const std::shared_ptr<ModelInterface> &model) {
+    return model->ClearLabel(id_, label_);
+}

--- a/src/ui/actions/ClearLabelOfTaskAction.h
+++ b/src/ui/actions/ClearLabelOfTaskAction.h
@@ -1,0 +1,23 @@
+//
+// Created by Anton O. on 1/17/22.
+//
+
+#ifndef TASKMANAGER_SRC_UI_ACTIONS_CLEARLABELOFTASKACTTION_H_
+#define TASKMANAGER_SRC_UI_ACTIONS_CLEARLABELOFTASKACTTION_H_
+
+#include "Action.h"
+
+class ClearLabelOfTaskAction : public Action {
+public:
+    ClearLabelOfTaskAction(const Core::TaskID &, const std::string &label);
+
+public:
+    ActionResult execute(const std::shared_ptr<ModelInterface> &) override;
+
+private:
+    Core::TaskID id_;
+    std::string label_;
+};
+
+
+#endif //TASKMANAGER_SRC_UI_ACTIONS_CLEARLABELOFTASKACTTION_H_

--- a/src/ui/actions/ClearLabelOfTaskAction.h
+++ b/src/ui/actions/ClearLabelOfTaskAction.h
@@ -9,7 +9,7 @@
 
 class ClearLabelOfTaskAction : public Action {
 public:
-    ClearLabelOfTaskAction(const Core::TaskID &, const std::string &label);
+    explicit ClearLabelOfTaskAction(const Core::TaskID &, const std::string &label);
 
 public:
     ActionResult execute(const std::shared_ptr<ModelInterface> &) override;

--- a/src/ui/actions/GetTaskToShowLabelsAction.cpp
+++ b/src/ui/actions/GetTaskToShowLabelsAction.cpp
@@ -1,0 +1,23 @@
+//
+// Created by Anton Ovcharenko on 18.01.2022.
+//
+
+#include "GetTaskToShowLabelsAction.h"
+
+GetTaskToShowLabelsAction::GetTaskToShowLabelsAction(const std::string &arg) : arg_{arg} {
+}
+
+ActionResult GetTaskToShowLabelsAction::execute(const std::shared_ptr<ModelInterface> &model) {
+    std::optional<Core::TaskID> id{Core::TaskID()};
+    try {
+        id->set_value(std::stoi(arg_));
+        if (!model->Validate(*id))
+            return {ActionResult::Status::ID_NOT_FOUND, id};
+    } catch (const std::invalid_argument &) {
+        return {ActionResult::Status::TAKES_ID, std::nullopt};
+    }
+
+    std::vector<Core::TaskEntity> tasks = model->getTasks(*id);
+    tasks.erase(tasks.begin() + 1, tasks.end());
+    return {ActionResult::Status::SUCCESS, tasks};
+}

--- a/src/ui/actions/GetTaskToShowLabelsAction.h
+++ b/src/ui/actions/GetTaskToShowLabelsAction.h
@@ -1,0 +1,22 @@
+//
+// Created by Anton Ovcharenko on 18.01.2022.
+//
+
+#ifndef TASKMANAGER_SRC_UI_ACTIONS_GETTASKTOSHOWLABELSACTION_H_
+#define TASKMANAGER_SRC_UI_ACTIONS_GETTASKTOSHOWLABELSACTION_H_
+
+#include "Action.h"
+
+class GetTaskToShowLabelsAction : public Action {
+public:
+    explicit GetTaskToShowLabelsAction(const std::string &arg);
+
+public:
+    ActionResult execute(const std::shared_ptr<ModelInterface> &) override;
+
+private:
+    std::string arg_;
+};
+
+
+#endif //TASKMANAGER_SRC_UI_ACTIONS_GETTASKTOSHOWLABELSACTION_H_

--- a/src/ui/steps/ClearAllLabelsStep.cpp
+++ b/src/ui/steps/ClearAllLabelsStep.cpp
@@ -1,0 +1,15 @@
+//
+// Created by Anton O. on 1/17/22.
+//
+
+#include "ClearAllLabelsStep.h"
+#include "ui/Context.h"
+
+std::unique_ptr<Action> ClearAllLabelsStep::genAction(Context &context) {
+    return std::unique_ptr<Action>(new ClearAllLabelsOfTaskAction(*context.id()));
+}
+
+std::shared_ptr<Step> ClearAllLabelsStep::genNextStep(const ActionResult &result, const std::shared_ptr<Factory> &factory) {
+    return processResult(*this, factory, result, "Removed all labels of the task");
+
+}

--- a/src/ui/steps/ClearAllLabelsStep.h
+++ b/src/ui/steps/ClearAllLabelsStep.h
@@ -1,0 +1,21 @@
+//
+// Created by Anton O. on 1/17/22.
+//
+
+#ifndef TASKMANAGER_SRC_UI_STEPS_CLEARALLLABELSSTEP_H_
+#define TASKMANAGER_SRC_UI_STEPS_CLEARALLLABELSSTEP_H_
+
+
+#include "Step.h"
+#include "utilities/StepUtils.h"
+#include "ui/actions/ClearAllLabelsOfTaskAction.h"
+
+class ClearAllLabelsStep : public Step {
+public:
+    using Step::Step;
+    std::unique_ptr<Action> genAction(Context &) override;
+    std::shared_ptr<Step> genNextStep(const ActionResult &, const std::shared_ptr<Factory> &) override;
+};
+
+
+#endif //TASKMANAGER_SRC_UI_STEPS_CLEARALLLABELSSTEP_H_

--- a/src/ui/steps/ClearAllLabelsStep.h
+++ b/src/ui/steps/ClearAllLabelsStep.h
@@ -6,13 +6,13 @@
 #define TASKMANAGER_SRC_UI_STEPS_CLEARALLLABELSSTEP_H_
 
 
-#include "Step.h"
+#include "IOStep.h"
 #include "utilities/StepUtils.h"
 #include "ui/actions/ClearAllLabelsOfTaskAction.h"
 
-class ClearAllLabelsStep : public Step {
+class ClearAllLabelsStep : public IOStep {
 public:
-    using Step::Step;
+    using IOStep::IOStep;
     std::unique_ptr<Action> genAction(Context &) override;
     std::shared_ptr<Step> genNextStep(const ActionResult &, const std::shared_ptr<Factory> &) override;
 };

--- a/src/ui/steps/ClearLabelStep.cpp
+++ b/src/ui/steps/ClearLabelStep.cpp
@@ -1,0 +1,23 @@
+//
+// Created by Anton O. on 1/17/22.
+//
+
+#include "ClearLabelStep.h"
+#include "ui/Context.h"
+
+std::unique_ptr<Action> ClearLabelStep::genAction(Context &context) {
+    std::string label = readLabel();
+    return std::unique_ptr<Action>(new ClearLabelOfTaskAction(*context.id(), label));
+}
+
+std::shared_ptr<Step> ClearLabelStep::genNextStep(const ActionResult &result, const std::shared_ptr<Factory> &factory) {
+    return processResult(*this, factory, result, "Removed label from task");
+
+}
+
+std::string ClearLabelStep::readLabel() const {
+    std::string label = reader()->read("[Clear Label]\n    >> ");
+    while (label.empty())
+        label = reader()->read("Label cannot be empty. Try again.\n    >> ");
+    return label;
+}

--- a/src/ui/steps/ClearLabelStep.h
+++ b/src/ui/steps/ClearLabelStep.h
@@ -6,13 +6,13 @@
 #ifndef TASKMANAGER_SRC_UI_STEPS_CLEARLABELSTEP_H_
 #define TASKMANAGER_SRC_UI_STEPS_CLEARLABELSTEP_H_
 
-#include "Step.h"
+#include "IOStep.h"
 #include "utilities/StepUtils.h"
 #include "ui/actions/ClearLabelOfTaskAction.h"
 
-class ClearLabelStep : public Step {
+class ClearLabelStep : public IOStep {
 public:
-    using Step::Step;
+    using IOStep::IOStep;
     std::unique_ptr<Action> genAction(Context &) override;
     std::shared_ptr<Step> genNextStep(const ActionResult &, const std::shared_ptr<Factory> &) override;
 

--- a/src/ui/steps/ClearLabelStep.h
+++ b/src/ui/steps/ClearLabelStep.h
@@ -1,0 +1,24 @@
+
+//
+// Created by Anton O. on 1/17/22.
+//
+
+#ifndef TASKMANAGER_SRC_UI_STEPS_CLEARLABELSTEP_H_
+#define TASKMANAGER_SRC_UI_STEPS_CLEARLABELSTEP_H_
+
+#include "Step.h"
+#include "utilities/StepUtils.h"
+#include "ui/actions/ClearLabelOfTaskAction.h"
+
+class ClearLabelStep : public Step {
+public:
+    using Step::Step;
+    std::unique_ptr<Action> genAction(Context &) override;
+    std::shared_ptr<Step> genNextStep(const ActionResult &, const std::shared_ptr<Factory> &) override;
+
+public:
+    std::string readLabel() const;
+};
+
+
+#endif //TASKMANAGER_SRC_UI_STEPS_CLEARLABELSTEP_H_

--- a/src/ui/steps/HomeStep.cpp
+++ b/src/ui/steps/HomeStep.cpp
@@ -16,10 +16,13 @@ std::unique_ptr<Action> HomeStep::genAction(Context &) {
 
     if (command_ == "edit" || command_ == "subtask" ||
         command_ == "delete" || command_ == "complete" ||
-        command_ == "uncomplete" || command_ == "label") {
+        command_ == "uncomplete" || command_ == "label" ||
+        command_ == "unlabel" || command_ == "UNLABEL") {
         return std::unique_ptr<Action>(new ValidateIDAction(arg));
     } else if (command_ == "show") {
         return std::unique_ptr<Action>(new GetTasksToShowAction(arg));
+    } else if (command_ == "labels") {
+        return std::unique_ptr<Action>(new GetTaskToShowLabelsAction(arg));
     } else if (command_ == "save") {
         return std::unique_ptr<Action>(new SaveToFileAction(arg));
     } else if (command_ == "load") {

--- a/src/ui/steps/HomeStep.h
+++ b/src/ui/steps/HomeStep.h
@@ -14,6 +14,7 @@
 #include "ui/actions/GetTasksToShowAction.h"
 #include "ui/actions/LoadFromFileAction.h"
 #include "ui/actions/SaveToFileAction.h"
+#include "ui/actions/GetTaskToShowLabelsAction.h"
 
 class HomeStep : public Step {
 public:

--- a/src/ui/steps/ShowAllLabelsStep.cpp
+++ b/src/ui/steps/ShowAllLabelsStep.cpp
@@ -6,12 +6,19 @@
 #include "ui/Context.h"
 
 std::unique_ptr<Action> ShowAllLabelsStep::genAction(Context &context) {
+    std::ostringstream os;
     if (!context.tasks().empty()) {
         auto labels = context.tasks()[0].data().labels();
-        for (auto it = labels.begin(); it != labels.end(); ++it)
-            printer()->print(*it + " ");
+        for (int i = 0; i < labels.size(); ++i) {
+            os << labels[i];
+            if (i < labels.size()-1)
+                os << ", ";
+        }
+
         if (!labels.empty())
-            printer()->print("\n");
+            os << "\n";
+
+        printer()->print(os.str());
     }
     return std::unique_ptr<Action>(new DoNothingAction);
 }

--- a/src/ui/steps/ShowAllLabelsStep.cpp
+++ b/src/ui/steps/ShowAllLabelsStep.cpp
@@ -1,0 +1,20 @@
+//
+// Created by Anton Ovcharenko on 18.01.2022.
+//
+
+#include "ShowAllLabelsStep.h"
+#include "ui/Context.h"
+
+std::unique_ptr<Action> ShowAllLabelsStep::genAction(Context &context) {
+    auto labels = context.tasks()[0].data().labels();
+    for (auto it = labels.begin(); it != labels.end(); ++it)
+        printer()->print(*it + " ");
+    if (!labels.empty())
+        printer()->print("\n");
+    return std::unique_ptr<Action>(new DoNothingAction);
+}
+
+std::shared_ptr<Step> ShowAllLabelsStep::genNextStep(const ActionResult &result, const std::shared_ptr<Factory> &factory) {
+    return processResult(*this, factory, result, "");
+
+}

--- a/src/ui/steps/ShowAllLabelsStep.cpp
+++ b/src/ui/steps/ShowAllLabelsStep.cpp
@@ -6,11 +6,13 @@
 #include "ui/Context.h"
 
 std::unique_ptr<Action> ShowAllLabelsStep::genAction(Context &context) {
-    auto labels = context.tasks()[0].data().labels();
-    for (auto it = labels.begin(); it != labels.end(); ++it)
-        printer()->print(*it + " ");
-    if (!labels.empty())
-        printer()->print("\n");
+    if (!context.tasks().empty()) {
+        auto labels = context.tasks()[0].data().labels();
+        for (auto it = labels.begin(); it != labels.end(); ++it)
+            printer()->print(*it + " ");
+        if (!labels.empty())
+            printer()->print("\n");
+    }
     return std::unique_ptr<Action>(new DoNothingAction);
 }
 

--- a/src/ui/steps/ShowAllLabelsStep.h
+++ b/src/ui/steps/ShowAllLabelsStep.h
@@ -5,13 +5,13 @@
 #ifndef TASKMANAGER_SRC_UI_STEPS_SHOWALLLABELSSTEP_H_
 #define TASKMANAGER_SRC_UI_STEPS_SHOWALLLABELSSTEP_H_
 
-#include "Step.h"
+#include "IOStep.h"
 #include "utilities/StepUtils.h"
 #include "ui/actions/DoNothingAction.h"
 
-class ShowAllLabelsStep : public Step {
+class ShowAllLabelsStep : public IOStep {
 public:
-    using Step::Step;
+    using IOStep::IOStep;
     std::unique_ptr<Action> genAction(Context &) override;
     std::shared_ptr<Step> genNextStep(const ActionResult &, const std::shared_ptr<Factory> &) override;
 };

--- a/src/ui/steps/ShowAllLabelsStep.h
+++ b/src/ui/steps/ShowAllLabelsStep.h
@@ -1,0 +1,20 @@
+//
+// Created by Anton Ovcharenko on 18.01.2022.
+//
+
+#ifndef TASKMANAGER_SRC_UI_STEPS_SHOWALLLABELSSTEP_H_
+#define TASKMANAGER_SRC_UI_STEPS_SHOWALLLABELSSTEP_H_
+
+#include "Step.h"
+#include "utilities/StepUtils.h"
+#include "ui/actions/DoNothingAction.h"
+
+class ShowAllLabelsStep : public Step {
+public:
+    using Step::Step;
+    std::unique_ptr<Action> genAction(Context &) override;
+    std::shared_ptr<Step> genNextStep(const ActionResult &, const std::shared_ptr<Factory> &) override;
+};
+
+
+#endif //TASKMANAGER_SRC_UI_STEPS_SHOWALLLABELSSTEP_H_

--- a/test/model/TaskManagerTest.cpp
+++ b/test/model/TaskManagerTest.cpp
@@ -299,6 +299,84 @@ TEST_F(TaskManagerTest, shouldAddMultipleLabels){
     EXPECT_EQ(label2, tm.getTasks()[0].data().labels()[1]);
 }
 
+TEST_F(TaskManagerTest, shouldAddMultipleLabelsClearOne){
+    TaskManager tm;
+    Core::Task::Priority p = Core::Task::Priority::Task_Priority_NONE;
+    Core::Task t;
+    t.set_title("Task");
+    t.set_priority(p);
+    t.set_due_date(time(nullptr));
+    t.set_is_complete(false);
+    Core::TaskID id = *tm.Add(t).id;
+    std::string label = "testing";
+    std::string label2 = "testing2";
+    tm.AddLabel(id, label);
+    tm.AddLabel(id, label2);
+    tm.ClearLabel(id, label);
+    auto tasks = tm.getTasks();
+    EXPECT_EQ(1, tasks[0].data().labels().size());
+    EXPECT_EQ(label2, tasks[0].data().labels()[0]);
+}
+
+TEST_F(TaskManagerTest, shouldFailToClearLabelInvalidID){
+    TaskManager tm;
+    Core::Task::Priority p = Core::Task::Priority::Task_Priority_NONE;
+    Core::Task t;
+    t.set_title("Task");
+    t.set_priority(p);
+    t.set_due_date(time(nullptr));
+    t.set_is_complete(false);
+    Core::TaskID id = *tm.Add(t).id;
+    std::string label = "testing";
+    tm.AddLabel(id, label);
+    Core::TaskID id2;
+    id2.set_value(id.value()+1);
+    ActionResult result = tm.ClearLabel(id2, label);
+    auto tasks = tm.getTasks();
+    EXPECT_EQ(1, tasks[0].data().labels().size());
+    EXPECT_EQ(label, tasks[0].data().labels()[0]);
+    EXPECT_EQ(result.status, ActionResult::Status::ID_NOT_FOUND);
+    EXPECT_EQ(*result.id, id2);
+}
+
+TEST_F(TaskManagerTest, shouldFailToClearAllLabelsInvalidID){
+    TaskManager tm;
+    Core::Task::Priority p = Core::Task::Priority::Task_Priority_NONE;
+    Core::Task t;
+    t.set_title("Task");
+    t.set_priority(p);
+    t.set_due_date(time(nullptr));
+    t.set_is_complete(false);
+    Core::TaskID id = *tm.Add(t).id;
+    std::string label = "testing";
+    tm.AddLabel(id, label);
+    Core::TaskID id2;
+    id2.set_value(id.value()+1);
+    ActionResult result = tm.ClearLabels(id2);
+    auto tasks = tm.getTasks();
+    EXPECT_EQ(1, tasks[0].data().labels().size());
+    EXPECT_EQ(label, tasks[0].data().labels()[0]);
+    EXPECT_EQ(result.status, ActionResult::Status::ID_NOT_FOUND);
+    EXPECT_EQ(*result.id, id2);
+}
+
+TEST_F(TaskManagerTest, shouldAddMultipleLabelsClearAll){
+    TaskManager tm;
+    Core::Task::Priority p = Core::Task::Priority::Task_Priority_NONE;
+    Core::Task t;
+    t.set_title("Task");
+    t.set_priority(p);
+    t.set_due_date(time(nullptr));
+    t.set_is_complete(false);
+    Core::TaskID id = *tm.Add(t).id;
+    std::string label = "testing";
+    std::string label2 = "testing2";
+    tm.AddLabel(id, label);
+    tm.AddLabel(id, label2);
+    tm.ClearLabels(id);
+    EXPECT_TRUE(tm.getTasks()[0].data().labels().empty());
+}
+
 TEST_F(TaskManagerTest, shouldFailToAddLabelWithWrongID){
     TaskManager tm;
     Core::Task::Priority p = Core::Task::Priority::Task_Priority_NONE;

--- a/test/model/TaskManagerTest.cpp
+++ b/test/model/TaskManagerTest.cpp
@@ -314,7 +314,7 @@ TEST_F(TaskManagerTest, shouldAddMultipleLabelsClearOne){
     tm.AddLabel(id, label2);
     tm.ClearLabel(id, label);
     auto tasks = tm.getTasks();
-    EXPECT_EQ(1, tasks[0].data().labels().size());
+    ASSERT_EQ(1, tasks[0].data().labels().size());
     EXPECT_EQ(label2, tasks[0].data().labels()[0]);
 }
 
@@ -333,7 +333,7 @@ TEST_F(TaskManagerTest, shouldFailToClearLabelInvalidID){
     id2.set_value(id.value()+1);
     ActionResult result = tm.ClearLabel(id2, label);
     auto tasks = tm.getTasks();
-    EXPECT_EQ(1, tasks[0].data().labels().size());
+    ASSERT_EQ(1, tasks[0].data().labels().size());
     EXPECT_EQ(label, tasks[0].data().labels()[0]);
     EXPECT_EQ(result.status, ActionResult::Status::ID_NOT_FOUND);
     EXPECT_EQ(*result.id, id2);
@@ -354,7 +354,7 @@ TEST_F(TaskManagerTest, shouldFailToClearAllLabelsInvalidID){
     id2.set_value(id.value()+1);
     ActionResult result = tm.ClearLabels(id2);
     auto tasks = tm.getTasks();
-    EXPECT_EQ(1, tasks[0].data().labels().size());
+    ASSERT_EQ(1, tasks[0].data().labels().size());
     EXPECT_EQ(label, tasks[0].data().labels()[0]);
     EXPECT_EQ(result.status, ActionResult::Status::ID_NOT_FOUND);
     EXPECT_EQ(*result.id, id2);

--- a/test/ui/ActionTest.cpp
+++ b/test/ui/ActionTest.cpp
@@ -19,6 +19,9 @@
 #include "ui/actions/LabelTaskAction.h"
 #include "ui/actions/LoadFromFileAction.h"
 #include "ui/actions/SaveToFileAction.h"
+#include "ui/actions/ClearLabelOfTaskAction.h"
+#include "ui/actions/ClearAllLabelsOfTaskAction.h"
+#include "ui/actions/GetTaskToShowLabelsAction.h"
 
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
@@ -280,9 +283,64 @@ TEST_F(ActionTest, shouldDoNothing)
     EXPECT_EQ(std::nullopt, result.id);
 
 }
-class MockPersister : public FilePersistence {
-public:
-    MOCK_METHOD(bool, save, (const std::vector<Core::TaskEntity> &vec), (override));
-    MOCK_METHOD(bool, load, (std::vector<Core::TaskEntity> &vec), (override));
-};
 
+TEST_F(ActionTest, shouldClearAllLabelsOfTask)
+{
+    LabelTaskAction label_action(id_, "mylabel");
+    LabelTaskAction label_action2(id_, "mylabel2");
+    label_action.execute(tm_);
+    label_action2.execute(tm_);
+
+    ClearAllLabelsOfTaskAction act{id_};
+    ActionResult result = act.execute(tm_);
+    ASSERT_EQ(1, tm_->size());
+    EXPECT_EQ(result.status, ActionResult::Status::SUCCESS);
+    EXPECT_EQ(id_, *result.id);
+    auto tasks = tm_->getTasks(id_);
+    EXPECT_TRUE(tasks[0].data().labels().empty());
+}
+
+TEST_F(ActionTest, shouldClearOneLabelOfTask)
+{
+    LabelTaskAction label_action(id_, "mylabel");
+    LabelTaskAction label_action2(id_, "mylabel2");
+    label_action.execute(tm_);
+    label_action2.execute(tm_);
+
+    ClearLabelOfTaskAction act{id_, "mylabel2"};
+    ActionResult result = act.execute(tm_);
+    ASSERT_EQ(1, tm_->size());
+    EXPECT_EQ(result.status, ActionResult::Status::SUCCESS);
+    EXPECT_EQ(id_, *result.id);
+    auto tasks = tm_->getTasks(id_);
+    EXPECT_EQ(2, tasks[0].data().labels().size());
+    EXPECT_EQ("mylabel", tasks[0].data().labels()[1]);
+}
+
+TEST_F(ActionTest, shouldGetTaskToShowItsLabels)
+{
+    GetTaskToShowLabelsAction act{std::to_string(id_.value())};
+    ActionResult result = act.execute(tm_);
+    ASSERT_EQ(1, tm_->size());
+    EXPECT_EQ(result.status, ActionResult::Status::SUCCESS);
+    auto tasks = tm_->getTasks(id_);
+    EXPECT_EQ(1, result.tasks.size());
+    EXPECT_EQ(tasks[0], result.tasks[0]);
+}
+
+TEST_F(ActionTest, shouldFailToGetTaskToShowItsLabelsWithInvalidID)
+{
+    GetTaskToShowLabelsAction act{std::to_string(id_.value() + 1)};
+    ActionResult result = act.execute(tm_);
+    ASSERT_EQ(1, tm_->size());
+    EXPECT_EQ(result.status, ActionResult::Status::ID_NOT_FOUND);
+}
+
+TEST_F(ActionTest, shouldFailToGetTaskToShowItsLabelsWithInvalidArg)
+{
+    GetTaskToShowLabelsAction act{"bad"};
+    ActionResult result = act.execute(tm_);
+    ASSERT_EQ(1, tm_->size());
+    EXPECT_EQ(result.status, ActionResult::Status::TAKES_ID);
+    EXPECT_EQ(std::nullopt, result.id);
+}

--- a/test/ui/IntegrationTest.cpp
+++ b/test/ui/IntegrationTest.cpp
@@ -552,3 +552,100 @@ TEST_F(IntegrationTest, shouldAddMultipleLabels)
         EXPECT_EQ(out[i], expected_outputs[i]);
     }
 }
+
+
+TEST_F(IntegrationTest, shouldClearSomeLabels)
+{
+    std::vector<std::string> scenario = {"add", "test", "1", "21/12/25",
+                                         "label 1", "l1", "label 1", "l2", "label 1", "l3", "show",
+                                         "unlabel 1", "", "l1", "unlabel 1", "l3", "show", "quit"};
+
+    std::vector<std::string> expected_outputs = {"[Add Task]\n",
+                                                 "Added Task", " (ID: 1)\n",
+                                                 "Added label to Task", " (ID: 1)\n",
+                                                 "Added label to Task", " (ID: 1)\n",
+                                                 "Added label to Task", " (ID: 1)\n",
+                                                 "1 – test, Priority: Low, Due: Sun Dec 21 00:00:00 2025, has 3 label(s)", "\n",
+                                                 "Removed label from task", " (ID: 1)\n",
+                                                 "Removed label from task", " (ID: 1)\n",
+                                                 "1 – test, Priority: Low, Due: Sun Dec 21 00:00:00 2025, has 1 label(s)", "\n"};
+
+    auto f = Factory::create(std::shared_ptr<AbstractReader>(new MockReaderToVector{scenario}),
+                             std::shared_ptr<AbstractPrinter>(new MockPrinterToVector));
+
+    auto tm = std::make_shared<TaskManager>();
+    Machine m(tm, f, Factory::State::HOME);
+    m.run();
+
+    ASSERT_EQ(1, tm->size());
+
+    auto mp = *std::dynamic_pointer_cast<MockPrinterToVector>(f->printer());
+    auto out = mp.messages();
+    ASSERT_EQ(out.size(), expected_outputs.size());
+    for (int i = 0; i <  out.size(); ++i) {
+        EXPECT_EQ(out[i], expected_outputs[i]);
+    }
+}
+
+TEST_F(IntegrationTest, shouldClearAllLabels)
+{
+    std::vector<std::string> scenario = {"add", "test", "1", "21/12/25",
+                                         "label 1", "l1", "label 1", "l2", "label 1", "l3", "show",
+                                         "UNLABEL 1", "show", "quit"};
+
+    std::vector<std::string> expected_outputs = {"[Add Task]\n",
+                                                 "Added Task", " (ID: 1)\n",
+                                                 "Added label to Task", " (ID: 1)\n",
+                                                 "Added label to Task", " (ID: 1)\n",
+                                                 "Added label to Task", " (ID: 1)\n",
+                                                 "1 – test, Priority: Low, Due: Sun Dec 21 00:00:00 2025, has 3 label(s)", "\n",
+                                                 "Removed all labels of the task", " (ID: 1)\n",
+                                                 "1 – test, Priority: Low, Due: Sun Dec 21 00:00:00 2025", "\n"};
+
+    auto f = Factory::create(std::shared_ptr<AbstractReader>(new MockReaderToVector{scenario}),
+                             std::shared_ptr<AbstractPrinter>(new MockPrinterToVector));
+
+    auto tm = std::make_shared<TaskManager>();
+    Machine m(tm, f, Factory::State::HOME);
+    m.run();
+
+    ASSERT_EQ(1, tm->size());
+
+    auto mp = *std::dynamic_pointer_cast<MockPrinterToVector>(f->printer());
+    auto out = mp.messages();
+    ASSERT_EQ(out.size(), expected_outputs.size());
+    for (int i = 0; i <  out.size(); ++i) {
+        EXPECT_EQ(out[i], expected_outputs[i]);
+    }
+}
+
+TEST_F(IntegrationTest, shouldAddAndShowMultipleLabels)
+{
+    std::vector<std::string> scenario = {"add", "test", "1", "21/12/25",
+                                         "label 1", "l1", "label 1", "l2", "label 1", "l3", "show",
+                                         "labels 1", "quit"};
+
+    std::vector<std::string> expected_outputs = {"[Add Task]\n",
+                                                 "Added Task", " (ID: 1)\n",
+                                                 "Added label to Task", " (ID: 1)\n",
+                                                 "Added label to Task", " (ID: 1)\n",
+                                                 "Added label to Task", " (ID: 1)\n",
+                                                 "1 – test, Priority: Low, Due: Sun Dec 21 00:00:00 2025, has 3 label(s)", "\n",
+                                                 "l1 ", "l2 ", "l3 ", "\n"};
+
+    auto f = Factory::create(std::shared_ptr<AbstractReader>(new MockReaderToVector{scenario}),
+                             std::shared_ptr<AbstractPrinter>(new MockPrinterToVector));
+
+    auto tm = std::make_shared<TaskManager>();
+    Machine m(tm, f, Factory::State::HOME);
+    m.run();
+
+    ASSERT_EQ(1, tm->size());
+
+    auto mp = *std::dynamic_pointer_cast<MockPrinterToVector>(f->printer());
+    auto out = mp.messages();
+    ASSERT_EQ(out.size(), expected_outputs.size());
+    for (int i = 0; i <  out.size(); ++i) {
+        EXPECT_EQ(out[i], expected_outputs[i]);
+    }
+}

--- a/test/ui/IntegrationTest.cpp
+++ b/test/ui/IntegrationTest.cpp
@@ -631,7 +631,7 @@ TEST_F(IntegrationTest, shouldAddAndShowMultipleLabels)
                                                  "Added label to Task", " (ID: 1)\n",
                                                  "Added label to Task", " (ID: 1)\n",
                                                  "1 – test, Priority: Low, Due: Sun Dec 21 00:00:00 2025, has 3 label(s)", "\n",
-                                                 "l1 ", "l2 ", "l3 ", "\n"};
+                                                 "l1, l2, l3\n"};
 
     auto f = Factory::create(std::shared_ptr<AbstractReader>(new MockReaderToVector{scenario}),
                              std::shared_ptr<AbstractPrinter>(new MockPrinterToVector));


### PR DESCRIPTION
There are three new commands:
• unlabel <id> - asks for label and removed it from task with ID <id>
• UNLABEL <id> - clears all labels of task with ID <id>
• labels <id> - shows string of labels of task with ID <id>