### PR TITLE
Fixed bug with Tasks accumulatting labels when being saved to file

### DIFF
--- a/src/persistence/FilePersistence.cpp
+++ b/src/persistence/FilePersistence.cpp
@@ -27,9 +27,9 @@ bool FilePersistence::load(std::vector<Core::TaskEntity> &vec) {
     std::ifstream file(filename_, std::ios::binary);
     google::protobuf::io::IstreamInputStream iis{&file};
     if (file.is_open()) {
-        Core::TaskEntity te;
         bool clean_eof = false;
         while (true) {
+            Core::TaskEntity te;
             google::protobuf::util::ParseDelimitedFromZeroCopyStream(&te, &iis, &clean_eof);
             if (!clean_eof)
                 vec.push_back(te);


### PR DESCRIPTION
The essence of the bug:
after labels were changed to be a repeated string, if we had three tasks with labels "1", "2", and "3", respectively, the first would be saved with label "1", second - {"1", "2"}, third - {"1", "2", "3"}.
By moving the initialization of the Core::TaskEntity object into the loop, the issue was solved.