### PR TITLE
TaskManager refactoring

### DIFF
--- a/src/model/ModelInterface.h
+++ b/src/model/ModelInterface.h
@@ -31,7 +31,7 @@ public:
     virtual ActionResult Complete(const Core::TaskID &) = 0;
     virtual ActionResult Uncomplete(const Core::TaskID &) = 0;
     virtual ActionResult Delete(const Core::TaskID &, bool deleteChildren) = 0;
-    virtual ActionResult Validate(const Core::TaskID &) const = 0;
+    virtual ActionResult IsPresent(const Core::TaskID &) const = 0;
     virtual ActionResult AddLabel(const Core::TaskID &, const std::string &label) = 0;
     virtual ActionResult ClearLabel(const Core::TaskID &, const std::string &label) = 0;
     virtual ActionResult ClearLabels(const Core::TaskID &) = 0;

--- a/src/model/ModelInterface.h
+++ b/src/model/ModelInterface.h
@@ -20,7 +20,7 @@ class ModelInterface {
 public:
     virtual std::vector<Core::TaskEntity> getTasks() const = 0;
     virtual std::vector<Core::TaskEntity> getTasks(const std::string &label) const = 0;
-    virtual std::vector<Core::TaskEntity> getTasks(const Core::TaskID &id) const = 0;
+    virtual std::vector<Core::TaskEntity> getTaskWithSubtasks(const Core::TaskID &id) const = 0;
     virtual std::shared_ptr<IDGenerator> gen() const = 0;
     virtual size_t size() const = 0;
 

--- a/src/model/ModelInterface.h
+++ b/src/model/ModelInterface.h
@@ -33,6 +33,8 @@ public:
     virtual ActionResult Delete(const Core::TaskID &, bool deleteChildren) = 0;
     virtual ActionResult Validate(const Core::TaskID &) const = 0;
     virtual ActionResult AddLabel(const Core::TaskID &, const std::string &label) = 0;
+    virtual ActionResult ClearLabel(const Core::TaskID &, const std::string &label) = 0;
+    virtual ActionResult ClearLabels(const Core::TaskID &) = 0;
 
 public:
     virtual void Replace(const std::vector<Core::TaskEntity> &) = 0;

--- a/src/model/TaskManager.cpp
+++ b/src/model/TaskManager.cpp
@@ -10,6 +10,42 @@ TaskManager::TaskManager() : gen_(std::shared_ptr<IDGenerator>(new IDGenerator))
 TaskManager::TaskManager(const std::shared_ptr<IDGenerator> &generator) : gen_(generator) {
 }
 
+void TaskManager::AddChild(const Core::TaskID &parent, const Core::TaskID &child) {
+    auto it = tasks_.find(parent);
+    if (it != tasks_.end())
+        it->second.second.AddChild(child);
+}
+
+void TaskManager::RemoveChild(const Core::TaskID &parent, const Core::TaskID &child) {
+    auto it = tasks_.find(parent);
+    if (it != tasks_.end())
+        it->second.second.RemoveChild(child);
+}
+
+std::optional<Core::Task> TaskManager::GetTask(const Core::TaskID &id) const {
+    auto it = tasks_.find(id);
+    if (it != tasks_.end())
+        return it->second.first;
+    else
+        return std::nullopt;
+}
+
+std::vector<Core::TaskID> TaskManager::ChildrenOf(const Core::TaskID &parent) const {
+    auto it = tasks_.find(parent);
+    if (it != tasks_.end())
+        return it->second.second.children();
+    else
+        return std::vector<Core::TaskID>{};
+}
+
+std::optional<Core::TaskID> TaskManager::ParentOf(const Core::TaskID &id) const {
+    auto it = tasks_.find(id);
+    if (it != tasks_.end())
+        return it->second.second.parent();
+    else
+        return std::nullopt;
+}
+
 ActionResult TaskManager::Add(const Core::Task &t) {
     Core::TaskID id = gen_->genID();
     if (Validate(id))
@@ -27,7 +63,7 @@ ActionResult TaskManager::AddSubtask(const Core::Task &t, const Core::TaskID &pa
         return {ActionResult::Status::PARENT_ID_NOT_FOUND, parent};
 
     tasks_.insert(std::make_pair(id, std::make_pair(t, Node(parent))));
-    tasks_.at(parent).second.AddChild(id);
+    AddChild(parent, id);
     return {ActionResult::Status::SUCCESS, id};
 }
 
@@ -48,27 +84,32 @@ std::vector<Core::TaskEntity> TaskManager::getTasks() const {
 std::vector<Core::TaskEntity> TaskManager::getTasks(const std::string &label) const {
     std::vector<Core::TaskEntity> tasks;
     for (const auto &kv : tasks_) {
-        if (kv.second.first.label() == label) {
-            Core::TaskEntity te;
-            te.set_allocated_id(new Core::TaskID(kv.first));
-            te.set_allocated_data(new Core::Task(kv.second.first));
-            tasks.push_back(te);
+        for (const auto &task_label : kv.second.first.labels()) {
+            if (task_label == label) {
+                Core::TaskEntity te;
+                te.set_allocated_id(new Core::TaskID(kv.first));
+                te.set_allocated_data(new Core::Task(kv.second.first));
+                tasks.push_back(te);
+                break;
+            }
         }
     }
     return tasks;
 }
 
-std::vector<Core::TaskEntity> TaskManager::getTasks(const Core::TaskID &id) const {
+std::vector<Core::TaskEntity> TaskManager::getTaskWithSubtasks(const Core::TaskID &id) const {
     std::vector<Core::TaskEntity> tasks;
     Core::TaskEntity te;
     te.set_allocated_id(new Core::TaskID(id));
-    te.set_allocated_data(new Core::Task(tasks_.at(id).first));
+    std::optional<Core::Task> task = GetTask(id);
+    if (task)
+        te.set_allocated_data(new Core::Task(*task));
     // not including parent, but will include children
     tasks.push_back(te);
-    for (const auto &ch_id : tasks_.at(id).second.children()) {
-        auto ch_tasks = getTasks(ch_id);
+    for (const auto &ch_id : ChildrenOf(id)) {
+        auto ch_tasks = getTaskWithSubtasks(ch_id);
         for (auto &ch_task : ch_tasks) {
-            ch_task.set_allocated_parent(new Core::TaskID(*tasks_.at(ch_task.id()).second.parent()));
+            ch_task.set_allocated_parent(new Core::TaskID(*ParentOf(ch_task.id())));
         }
         tasks.insert(tasks.end(), ch_tasks.begin(), ch_tasks.end());
     }
@@ -76,48 +117,52 @@ std::vector<Core::TaskEntity> TaskManager::getTasks(const Core::TaskID &id) cons
 }
 
 ActionResult TaskManager::Delete(const Core::TaskID &id, bool deleteChildren) {
-    try {
-        if (!tasks_.at(id).second.children().empty() && !deleteChildren)
+    if (Validate(id)) {
+        if (!ChildrenOf(id).empty() && !deleteChildren)
             return {ActionResult::Status::HAS_CHILDREN, id};
-        std::optional<Core::TaskID> ancestor = tasks_.at(id).second.parent();
-        if (ancestor && Validate(ancestor.value()))
-            tasks_.at(ancestor.value()).second.RemoveChild(id);
-        for (auto const &ch: tasks_.at(id).second.children())
+        std::optional<Core::TaskID> ancestor = ParentOf(id);
+        if (ancestor && Validate(*ancestor))
+            RemoveChild(*ancestor, id);
+        for (auto const &ch: ChildrenOf(id))
             Delete(ch, true);
         tasks_.erase(id);
         return {ActionResult::Status::SUCCESS, id};
-    } catch (const std::out_of_range &) {
+    } else {
         return {ActionResult::Status::ID_NOT_FOUND, id};
     }
 }
 
 ActionResult TaskManager::Edit(const Core::TaskID &id, const Core::Task &t) {
-    try {
-        tasks_.at(id).first = t;
+    auto it = tasks_.find(id);
+    if (it != tasks_.end()) {
+        it->second.first = t;
         return {ActionResult::Status::SUCCESS, id};
-    } catch (const std::out_of_range &) {
+    } else {
         return {ActionResult::Status::ID_NOT_FOUND, id};
     }
 }
 
 ActionResult TaskManager::Complete(const Core::TaskID &id) {
-    try {
-        tasks_.at(id).first.set_is_complete(true);
-    } catch (const std::out_of_range &) {
+    auto it = tasks_.find(id);
+    if (it != tasks_.end()) {
+        it->second.first.set_is_complete(true);
+    } else {
         return {ActionResult::Status::ID_NOT_FOUND, id};
     }
-    for (auto const &ch : tasks_.at(id).second.children())
+
+    for (auto const &ch : ChildrenOf(id))
         Complete(ch);
     return {ActionResult::Status::SUCCESS, id};
 }
 
 ActionResult TaskManager::Uncomplete(const Core::TaskID &id) {
-    try {
-        tasks_.at(id).first.set_is_complete(false);
-    } catch (const std::out_of_range &) {
+    auto it = tasks_.find(id);
+    if (it != tasks_.end()) {
+        it->second.first.set_is_complete(false);
+    } else {
         return {ActionResult::Status::ID_NOT_FOUND, id};
     }
-    for (auto const &ch : tasks_.at(id).second.children())
+    for (auto const &ch : ChildrenOf(id))
         Uncomplete(ch);
     return {ActionResult::Status::SUCCESS, id};
 }
@@ -134,10 +179,35 @@ size_t TaskManager::size() const {
 }
 
 ActionResult TaskManager::AddLabel(const Core::TaskID &id, const std::string &label) {
-    Core::Task t;
-    try {
-        tasks_.at(id).first.set_label(label);
-    } catch (const std::out_of_range &) {
+    auto it = tasks_.find(id);
+    if (it != tasks_.end()) {
+        auto labels = it->second.first.labels();
+        if (find(labels.begin(), labels.end(), label) == labels.end())
+            it->second.first.add_labels(label);
+    } else {
+        return {ActionResult::Status::ID_NOT_FOUND, id};
+    }
+    return {ActionResult::Status::SUCCESS, id};
+}
+
+ActionResult TaskManager::ClearLabel(const Core::TaskID &id, const std::string &label) {
+    auto it = tasks_.find(id);
+    if (it != tasks_.end()) {
+        auto labels = it->second.first.mutable_labels();
+        auto label_it = find(labels->begin(), labels->end(), label);
+        if (label_it != labels->end())
+            it->second.first.mutable_labels()->erase(label_it);
+    } else {
+        return {ActionResult::Status::ID_NOT_FOUND, id};
+    }
+    return {ActionResult::Status::SUCCESS, id};
+}
+
+ActionResult TaskManager::ClearLabels(const Core::TaskID &id) {
+    auto it = tasks_.find(id);
+    if (it != tasks_.end()) {
+        it->second.first.clear_labels();
+    } else {
         return {ActionResult::Status::ID_NOT_FOUND, id};
     }
     return {ActionResult::Status::SUCCESS, id};

--- a/src/model/TaskManager.cpp
+++ b/src/model/TaskManager.cpp
@@ -48,7 +48,7 @@ std::optional<Core::TaskID> TaskManager::ParentOf(const Core::TaskID &id) const 
 
 ActionResult TaskManager::Add(const Core::Task &t) {
     Core::TaskID id = gen_->genID();
-    if (Validate(id))
+    if (IsPresent(id))
         return {ActionResult::Status::DUPLICATE_ID, id};
 
     tasks_.insert(std::make_pair(id, std::make_pair(t, Node())));
@@ -57,9 +57,9 @@ ActionResult TaskManager::Add(const Core::Task &t) {
 
 ActionResult TaskManager::AddSubtask(const Core::Task &t, const Core::TaskID &parent) {
     Core::TaskID id = gen_->genID();
-    if (Validate(id))
+    if (IsPresent(id))
         return {ActionResult::Status::DUPLICATE_ID, id};
-    if (!Validate(parent))
+    if (!IsPresent(parent))
         return {ActionResult::Status::PARENT_ID_NOT_FOUND, parent};
 
     tasks_.insert(std::make_pair(id, std::make_pair(t, Node(parent))));
@@ -111,11 +111,11 @@ std::vector<Core::TaskEntity> TaskManager::getTaskWithSubtasks(const Core::TaskI
 }
 
 ActionResult TaskManager::Delete(const Core::TaskID &id, bool deleteChildren) {
-    if (Validate(id)) {
+    if (IsPresent(id)) {
         if (!ChildrenOf(id).empty() && !deleteChildren)
             return {ActionResult::Status::HAS_CHILDREN, id};
         std::optional<Core::TaskID> ancestor = ParentOf(id);
-        if (ancestor && Validate(*ancestor))
+        if (ancestor && IsPresent(*ancestor))
             RemoveChild(*ancestor, id);
         for (auto const &ch: ChildrenOf(id))
             Delete(ch, true);
@@ -161,7 +161,7 @@ ActionResult TaskManager::Uncomplete(const Core::TaskID &id) {
     return {ActionResult::Status::SUCCESS, id};
 }
 
-ActionResult TaskManager::Validate(const Core::TaskID &id) const{
+ActionResult TaskManager::IsPresent(const Core::TaskID &id) const{
     if (tasks_.find(id) != tasks_.end())
         return {ActionResult::Status::SUCCESS, id};
     else

--- a/src/model/TaskManager.cpp
+++ b/src/model/TaskManager.cpp
@@ -71,10 +71,10 @@ std::vector<Core::TaskEntity> TaskManager::getTasks() const {
     std::vector<Core::TaskEntity> vec;
     for (const auto &kv : tasks_) {
         Core::TaskEntity te;
-        te.set_allocated_id(new Core::TaskID(kv.first));
-        te.set_allocated_data(new Core::Task(kv.second.first));
+        te.mutable_id()->CopyFrom(kv.first);
+        te.mutable_data()->CopyFrom(kv.second.first);
         if (kv.second.second.parent()) {
-            te.set_allocated_parent(new Core::TaskID(*kv.second.second.parent()));
+            te.mutable_parent()->CopyFrom(*kv.second.second.parent());
         }
         vec.push_back(te);
     }
@@ -87,8 +87,8 @@ std::vector<Core::TaskEntity> TaskManager::getTasks(const std::string &label) co
         for (const auto &task_label : kv.second.first.labels()) {
             if (task_label == label) {
                 Core::TaskEntity te;
-                te.set_allocated_id(new Core::TaskID(kv.first));
-                te.set_allocated_data(new Core::Task(kv.second.first));
+                te.mutable_id()->CopyFrom(kv.first);
+                te.mutable_data()->CopyFrom(kv.second.first);
                 tasks.push_back(te);
                 break;
             }
@@ -100,16 +100,16 @@ std::vector<Core::TaskEntity> TaskManager::getTasks(const std::string &label) co
 std::vector<Core::TaskEntity> TaskManager::getTaskWithSubtasks(const Core::TaskID &id) const {
     std::vector<Core::TaskEntity> tasks;
     Core::TaskEntity te;
-    te.set_allocated_id(new Core::TaskID(id));
+    te.mutable_id()->CopyFrom(id);
     std::optional<Core::Task> task = GetTask(id);
     if (task)
-        te.set_allocated_data(new Core::Task(*task));
+        te.mutable_data()->CopyFrom(*task);
     // not including parent, but will include children
     tasks.push_back(te);
     for (const auto &ch_id : ChildrenOf(id)) {
         auto ch_tasks = getTaskWithSubtasks(ch_id);
         for (auto &ch_task : ch_tasks) {
-            ch_task.set_allocated_parent(new Core::TaskID(*ParentOf(ch_task.id())));
+            ch_task.mutable_parent()->CopyFrom(*ParentOf(ch_task.id()));
         }
         tasks.insert(tasks.end(), ch_tasks.begin(), ch_tasks.end());
     }

--- a/src/model/TaskManager.cpp
+++ b/src/model/TaskManager.cpp
@@ -10,16 +10,16 @@ TaskManager::TaskManager() : gen_(std::shared_ptr<IDGenerator>(new IDGenerator))
 TaskManager::TaskManager(const std::shared_ptr<IDGenerator> &generator) : gen_(generator) {
 }
 
-void TaskManager::AddChild(const Core::TaskID &parent, const Core::TaskID &child) {
-    auto it = tasks_.find(parent);
+void TaskManager::AddChild(const Core::TaskID &parent_id, const Core::TaskID &child_id) {
+    auto it = tasks_.find(parent_id);
     if (it != tasks_.end())
-        it->second.second.AddChild(child);
+        it->second.second.AddChild(child_id);
 }
 
-void TaskManager::RemoveChild(const Core::TaskID &parent, const Core::TaskID &child) {
-    auto it = tasks_.find(parent);
+void TaskManager::RemoveChild(const Core::TaskID &parent_id, const Core::TaskID &child_id) {
+    auto it = tasks_.find(parent_id);
     if (it != tasks_.end())
-        it->second.second.RemoveChild(child);
+        it->second.second.RemoveChild(child_id);
 }
 
 std::optional<Core::Task> TaskManager::GetTask(const Core::TaskID &id) const {
@@ -30,8 +30,8 @@ std::optional<Core::Task> TaskManager::GetTask(const Core::TaskID &id) const {
         return std::nullopt;
 }
 
-std::vector<Core::TaskID> TaskManager::ChildrenOf(const Core::TaskID &parent) const {
-    auto it = tasks_.find(parent);
+std::vector<Core::TaskID> TaskManager::ChildrenOf(const Core::TaskID &parent_id) const {
+    auto it = tasks_.find(parent_id);
     if (it != tasks_.end())
         return it->second.second.children();
     else

--- a/src/model/TaskManager.h
+++ b/src/model/TaskManager.h
@@ -7,6 +7,7 @@
 
 #include "utilities/TaskIDUtils.h"
 #include "utilities/TaskUtils.h"
+#include "utilities/TaskEntityUtils.h"
 #include "utilities/NodeUtils.h"
 #include "ModelInterface.h"
 #include "IDGenerator.h"

--- a/src/model/TaskManager.h
+++ b/src/model/TaskManager.h
@@ -20,7 +20,7 @@ public:
 public:
     std::vector<Core::TaskEntity> getTasks() const override;
     std::vector<Core::TaskEntity> getTasks(const std::string &label) const override;
-    std::vector<Core::TaskEntity> getTasks(const Core::TaskID &id) const override;
+    std::vector<Core::TaskEntity> getTaskWithSubtasks(const Core::TaskID &id) const override;
     std::shared_ptr<IDGenerator> gen() const override;
     size_t size() const override;
 
@@ -33,9 +33,20 @@ public:
     ActionResult Delete(const Core::TaskID &id, bool deleteChildren) override;
     ActionResult Validate(const Core::TaskID &id) const override;
     ActionResult AddLabel(const Core::TaskID &, const std::string &) override;
+    ActionResult ClearLabel(const Core::TaskID &, const std::string &) override;
+    ActionResult ClearLabels(const Core::TaskID &) override;
 
 public:
     void Replace(const std::vector<Core::TaskEntity> &) override;
+
+private:
+    void AddChild(const Core::TaskID &parent, const Core::TaskID &child);
+    void RemoveChild(const Core::TaskID &parent, const Core::TaskID &child);
+
+private:
+    std::optional<Core::Task> GetTask(const Core::TaskID &id) const;
+    std::vector<Core::TaskID> ChildrenOf(const Core::TaskID &parent) const;
+    std::optional<Core::TaskID> ParentOf(const Core::TaskID &id) const;
 
 private:
     std::map<Core::TaskID, std::pair<Core::Task, Node>> tasks_;

--- a/src/model/TaskManager.h
+++ b/src/model/TaskManager.h
@@ -40,7 +40,7 @@ public:
     void Replace(const std::vector<Core::TaskEntity> &) override;
 
 private:
-    void AddChild(const Core::TaskID &parent, const Core::TaskID &child);
+    void AddChild(const Core::TaskID &parent_id, const Core::TaskID &child_id);
     void RemoveChild(const Core::TaskID &parent, const Core::TaskID &child);
 
 private:

--- a/src/model/TaskManager.h
+++ b/src/model/TaskManager.h
@@ -32,7 +32,7 @@ public:
     ActionResult Complete(const Core::TaskID &) override;
     ActionResult Uncomplete(const Core::TaskID &) override;
     ActionResult Delete(const Core::TaskID &id, bool deleteChildren) override;
-    ActionResult Validate(const Core::TaskID &id) const override;
+    ActionResult IsPresent(const Core::TaskID &id) const override;
     ActionResult AddLabel(const Core::TaskID &, const std::string &) override;
     ActionResult ClearLabel(const Core::TaskID &, const std::string &) override;
     ActionResult ClearLabels(const Core::TaskID &) override;

--- a/src/ui/actions/GetTasksToShowAction.cpp
+++ b/src/ui/actions/GetTasksToShowAction.cpp
@@ -11,7 +11,7 @@ ActionResult GetTasksToShowAction::execute(const std::shared_ptr<ModelInterface>
     std::optional<Core::TaskID> id{Core::TaskID()};
     try {
         id->set_value(std::stoi(arg_));
-        if (!model->Validate(*id))
+        if (!model->IsPresent(*id))
             return {ActionResult::Status::ID_NOT_FOUND, id};
     } catch (const std::invalid_argument &) {
         id = std::nullopt;
@@ -21,7 +21,7 @@ ActionResult GetTasksToShowAction::execute(const std::shared_ptr<ModelInterface>
     if (arg_.empty())
         tasks = model->getTasks();
     else if (id)
-        tasks = model->getTasks(*id);
+        tasks = model->getTaskWithSubtasks(*id);
     else
         tasks = model->getTasks(arg_);
 

--- a/src/ui/actions/ValidateIDAction.cpp
+++ b/src/ui/actions/ValidateIDAction.cpp
@@ -14,9 +14,9 @@ ActionResult ValidateIDAction::execute(const std::shared_ptr<ModelInterface> &mo
         return {ActionResult::Status::TAKES_ARG, std::nullopt};
     try {
         id.set_value(std::stoi(arg_));
-        auto result = model->Validate(id);
+        auto result = model->IsPresent(id);
         if (result)
-            return {result.status, model->getTasks(id)};
+            return {result.status, model->getTaskWithSubtasks(id)};
         else
             return {result.status, id};
     } catch (const std::invalid_argument &) {

--- a/src/utilities/TaskEntityUtils.cpp
+++ b/src/utilities/TaskEntityUtils.cpp
@@ -10,6 +10,23 @@ bool Core::operator==(const Core::TaskEntity &lhs, const Core::TaskEntity &rhs) 
            lhs.data().due_date() == rhs.data().due_date() &&
            lhs.data().priority() == rhs.data().priority() &&
            lhs.data().is_complete() == rhs.data().is_complete() &&
-           lhs.data().label() == rhs.data().label() &&
+           lhs.data().labels() == rhs.data().labels() &&
            lhs.parent().value() == rhs.parent().value();
+}
+
+Core::TaskEntity  Core::createTaskEntity(const Core::TaskID &id,
+                                        const Core::Task &task,
+                                        const Core::TaskID &parent_id) {
+    Core::TaskEntity te;
+    te.mutable_id()->CopyFrom(id);
+    te.mutable_data()->CopyFrom(task);
+    te.mutable_parent()->CopyFrom(parent_id);
+    return te;
+}
+Core::TaskEntity  Core::createTaskEntity(const Core::TaskID &id,
+                                         const Core::Task &task) {
+    Core::TaskEntity te;
+    te.mutable_id()->CopyFrom(id);
+    te.mutable_data()->CopyFrom(task);
+    return te;
 }

--- a/src/utilities/TaskEntityUtils.h
+++ b/src/utilities/TaskEntityUtils.h
@@ -6,9 +6,15 @@
 #define TASKMANAGER_SRC_UTILITIES_TASKENTITYUTILS_H_
 
 #include "Task.pb.h"
+#include "TaskUtils.h"
 
 namespace Core {
 bool operator==(const Core::TaskEntity &lhs, const Core::TaskEntity &rhs);
+Core::TaskEntity createTaskEntity(const Core::TaskID &id,
+                                  const Core::Task &task,
+                                  const Core::TaskID &parent_it);
+Core::TaskEntity createTaskEntity(const Core::TaskID &id,
+                                  const Core::Task &task);
 }
 
 

--- a/test/model/TaskManagerTest.cpp
+++ b/test/model/TaskManagerTest.cpp
@@ -38,7 +38,7 @@ TEST_F(TaskManagerTest, shouldAddTask)
     t.set_title("TestTitle");
     t.set_priority(Core::Task::Priority::Task_Priority_NONE);
     t.set_due_date(time(nullptr) + 10);
-    t.set_label("label");
+    t.add_labels("label");
     t.set_is_complete(false);
     Core::TaskID id = *tm.Add(t).id;
     ASSERT_EQ(1, tm.size());
@@ -90,7 +90,7 @@ TEST_F(TaskManagerTest, shouldAddSubtask)
     t.set_title("TestTitle");
     t.set_priority(Core::Task::Priority::Task_Priority_NONE);
     t.set_due_date(time(nullptr) + 10);
-    t.set_label("label");
+    t.add_labels("label");
     t.set_is_complete(false);
     Core::TaskID id = *tm.Add(t).id;
     t.set_title("SubTask");
@@ -108,7 +108,7 @@ TEST_F(TaskManagerTest, shouldEdit)
     t.set_title("TestTitle");
     t.set_priority(Core::Task::Priority::Task_Priority_NONE);
     t.set_due_date(time(nullptr) + 10);
-    t.set_label("label");
+    t.add_labels("label");
     t.set_is_complete(false);
     Core::TaskID id = *tm.Add(t).id;
     t.set_title("Edited");
@@ -123,7 +123,7 @@ TEST_F(TaskManagerTest, shouldFailToEditWrongID)
     t.set_title("TestTitle");
     t.set_priority(Core::Task::Priority::Task_Priority_NONE);
     t.set_due_date(time(nullptr) + 10);
-    t.set_label("label");
+    t.add_labels("label");
     t.set_is_complete(false);
     Core::TaskID id = *tm.Add(t).id;
     t.set_title("Edited");
@@ -140,7 +140,7 @@ TEST_F(TaskManagerTest, shouldDeleteTask)
     t.set_title("TestTitle");
     t.set_priority(Core::Task::Priority::Task_Priority_NONE);
     t.set_due_date(time(nullptr) + 10);
-    t.set_label("label");
+    t.add_labels("label");
     t.set_is_complete(false);
     Core::TaskID id = *tm.Add(t).id;
     tm.Delete(id, false);
@@ -154,7 +154,7 @@ TEST_F(TaskManagerTest, shouldFailToDeleteTaskWithWrongID)
     t.set_title("TestTitle");
     t.set_priority(Core::Task::Priority::Task_Priority_NONE);
     t.set_due_date(time(nullptr) + 10);
-    t.set_label("label");
+    t.add_labels("label");
     t.set_is_complete(false);
     Core::TaskID id = *tm.Add(t).id;
     id.set_value(id.value()+1);
@@ -210,7 +210,7 @@ TEST_F(TaskManagerTest, shouldFailToCompleteTaskWithWrongID)
     t.set_title("TestTitle");
     t.set_priority(Core::Task::Priority::Task_Priority_NONE);
     t.set_due_date(time(nullptr) + 10);
-    t.set_label("label");
+    t.add_labels("label");
     t.set_is_complete(false);
     Core::TaskID id = *tm.Add(t).id;
     id.set_value(id.value()+1);
@@ -226,7 +226,7 @@ TEST_F(TaskManagerTest, shouldUncompleteTask)
     t.set_title("TestTitle");
     t.set_priority(Core::Task::Priority::Task_Priority_NONE);
     t.set_due_date(time(nullptr) + 10);
-    t.set_label("label");
+    t.add_labels("label");
     t.set_is_complete(true);
     Core::TaskID id = *tm.Add(t).id;
     tm.AddSubtask(t, id);
@@ -258,7 +258,6 @@ TEST_F(TaskManagerTest, shouldDeleteAncestorsChild)
     t.set_title("Task");
     t.set_priority(p);
     t.set_due_date(time(nullptr));
-    t.set_label("");
     t.set_is_complete(false);
     Core::TaskID id1 = *tm.Add(t).id;
     t.set_title("Subtask");
@@ -276,12 +275,106 @@ TEST_F(TaskManagerTest, shouldAddLabel){
     t.set_title("Task");
     t.set_priority(p);
     t.set_due_date(time(nullptr));
-    t.set_label("");
     t.set_is_complete(false);
     Core::TaskID id = *tm.Add(t).id;
     std::string label = "testing";
     tm.AddLabel(id, label);
-    EXPECT_EQ(label, tm.getTasks()[0].data().label());
+    EXPECT_EQ(label, tm.getTasks()[0].data().labels()[0]);
+}
+
+TEST_F(TaskManagerTest, shouldAddMultipleLabels){
+    TaskManager tm;
+    Core::Task::Priority p = Core::Task::Priority::Task_Priority_NONE;
+    Core::Task t;
+    t.set_title("Task");
+    t.set_priority(p);
+    t.set_due_date(time(nullptr));
+    t.set_is_complete(false);
+    Core::TaskID id = *tm.Add(t).id;
+    std::string label = "testing";
+    std::string label2 = "testing2";
+    tm.AddLabel(id, label);
+    tm.AddLabel(id, label2);
+    EXPECT_EQ(label, tm.getTasks()[0].data().labels()[0]);
+    EXPECT_EQ(label2, tm.getTasks()[0].data().labels()[1]);
+}
+
+TEST_F(TaskManagerTest, shouldAddMultipleLabelsClearOne){
+    TaskManager tm;
+    Core::Task::Priority p = Core::Task::Priority::Task_Priority_NONE;
+    Core::Task t;
+    t.set_title("Task");
+    t.set_priority(p);
+    t.set_due_date(time(nullptr));
+    t.set_is_complete(false);
+    Core::TaskID id = *tm.Add(t).id;
+    std::string label = "testing";
+    std::string label2 = "testing2";
+    tm.AddLabel(id, label);
+    tm.AddLabel(id, label2);
+    tm.ClearLabel(id, label);
+    auto tasks = tm.getTasks();
+    ASSERT_EQ(1, tasks[0].data().labels().size());
+    EXPECT_EQ(label2, tasks[0].data().labels()[0]);
+}
+
+TEST_F(TaskManagerTest, shouldFailToClearLabelInvalidID){
+    TaskManager tm;
+    Core::Task::Priority p = Core::Task::Priority::Task_Priority_NONE;
+    Core::Task t;
+    t.set_title("Task");
+    t.set_priority(p);
+    t.set_due_date(time(nullptr));
+    t.set_is_complete(false);
+    Core::TaskID id = *tm.Add(t).id;
+    std::string label = "testing";
+    tm.AddLabel(id, label);
+    Core::TaskID id2;
+    id2.set_value(id.value()+1);
+    ActionResult result = tm.ClearLabel(id2, label);
+    auto tasks = tm.getTasks();
+    ASSERT_EQ(1, tasks[0].data().labels().size());
+    EXPECT_EQ(label, tasks[0].data().labels()[0]);
+    EXPECT_EQ(result.status, ActionResult::Status::ID_NOT_FOUND);
+    EXPECT_EQ(*result.id, id2);
+}
+
+TEST_F(TaskManagerTest, shouldFailToClearAllLabelsInvalidID){
+    TaskManager tm;
+    Core::Task::Priority p = Core::Task::Priority::Task_Priority_NONE;
+    Core::Task t;
+    t.set_title("Task");
+    t.set_priority(p);
+    t.set_due_date(time(nullptr));
+    t.set_is_complete(false);
+    Core::TaskID id = *tm.Add(t).id;
+    std::string label = "testing";
+    tm.AddLabel(id, label);
+    Core::TaskID id2;
+    id2.set_value(id.value()+1);
+    ActionResult result = tm.ClearLabels(id2);
+    auto tasks = tm.getTasks();
+    ASSERT_EQ(1, tasks[0].data().labels().size());
+    EXPECT_EQ(label, tasks[0].data().labels()[0]);
+    EXPECT_EQ(result.status, ActionResult::Status::ID_NOT_FOUND);
+    EXPECT_EQ(*result.id, id2);
+}
+
+TEST_F(TaskManagerTest, shouldAddMultipleLabelsClearAll){
+    TaskManager tm;
+    Core::Task::Priority p = Core::Task::Priority::Task_Priority_NONE;
+    Core::Task t;
+    t.set_title("Task");
+    t.set_priority(p);
+    t.set_due_date(time(nullptr));
+    t.set_is_complete(false);
+    Core::TaskID id = *tm.Add(t).id;
+    std::string label = "testing";
+    std::string label2 = "testing2";
+    tm.AddLabel(id, label);
+    tm.AddLabel(id, label2);
+    tm.ClearLabels(id);
+    EXPECT_TRUE(tm.getTasks()[0].data().labels().empty());
 }
 
 TEST_F(TaskManagerTest, shouldFailToAddLabelWithWrongID){
@@ -291,7 +384,6 @@ TEST_F(TaskManagerTest, shouldFailToAddLabelWithWrongID){
     t.set_title("Task");
     t.set_priority(p);
     t.set_due_date(time(nullptr));
-    t.set_label("");
     t.set_is_complete(false);
     Core::TaskID id = *tm.Add(t).id;
     std::string label = "testing";
@@ -308,7 +400,6 @@ TEST_F(TaskManagerTest, shouldReturnTasks){
     t.set_title("TestTitle");
     t.set_priority(p);
     t.set_due_date(time(nullptr));
-    t.set_label("");
     t.set_is_complete(false);
     Core::TaskID id1 = *tm.Add(t).id;
 
@@ -340,7 +431,6 @@ TEST_F(TaskManagerTest, shouldReturnTasksWithSpecificID){
     t.set_title("TestTitle");
     t.set_priority(p);
     t.set_due_date(time(nullptr));
-    t.set_label("");
     t.set_is_complete(false);
     Core::TaskID id1 = *tm.Add(t).id;
 
@@ -352,7 +442,7 @@ TEST_F(TaskManagerTest, shouldReturnTasksWithSpecificID){
     t.set_due_date(time(nullptr) + 5);
     Core::TaskID id3 = *tm.AddSubtask(t, id2).id;
 
-    auto tasks = tm.getTasks(id2);
+    auto tasks = tm.getTaskWithSubtasks(id2);
     ASSERT_EQ(2, tasks.size());
     EXPECT_EQ("SubTask 1", tasks[0].data().title());
     EXPECT_EQ(id2, tasks[0].id());
@@ -369,7 +459,6 @@ TEST_F(TaskManagerTest, shouldReturnTasksWithSpecificLabel){
     t.set_title("TestTitle");
     t.set_priority(p);
     t.set_due_date(time(nullptr));
-    t.set_label("");
     t.set_is_complete(false);
     Core::TaskID id1 = *tm.Add(t).id;
 

--- a/test/model/TaskManagerTest.cpp
+++ b/test/model/TaskManagerTest.cpp
@@ -42,7 +42,7 @@ TEST_F(TaskManagerTest, shouldAddTask)
     t.set_is_complete(false);
     Core::TaskID id = *tm.Add(t).id;
     ASSERT_EQ(1, tm.size());
-    EXPECT_TRUE(tm.Validate(id));
+    EXPECT_TRUE(tm.IsPresent(id));
 }
 
 TEST_F(TaskManagerTest, shouldFailToAddTaskWithDuplicateID)
@@ -96,8 +96,8 @@ TEST_F(TaskManagerTest, shouldAddSubtask)
     t.set_title("SubTask");
     Core::TaskID id_ch = *tm.AddSubtask(t, id).id;
     ASSERT_EQ(2, tm.size());
-    EXPECT_TRUE(tm.Validate(id));
-    EXPECT_TRUE(tm.Validate(id_ch));
+    EXPECT_TRUE(tm.IsPresent(id));
+    EXPECT_TRUE(tm.IsPresent(id_ch));
     EXPECT_EQ(id, tm.getTasks()[1].parent());
 }
 
@@ -144,7 +144,7 @@ TEST_F(TaskManagerTest, shouldDeleteTask)
     t.set_is_complete(false);
     Core::TaskID id = *tm.Add(t).id;
     tm.Delete(id, false);
-    EXPECT_FALSE(tm.Validate(id));
+    EXPECT_FALSE(tm.IsPresent(id));
 }
 
 TEST_F(TaskManagerTest, shouldFailToDeleteTaskWithWrongID)

--- a/test/ui/ActionTest.cpp
+++ b/test/ui/ActionTest.cpp
@@ -52,7 +52,7 @@ public:
 TEST_F(ActionTest, shouldAddTask)
 {
     ASSERT_EQ(1, tm_->size());
-    EXPECT_TRUE(tm_->Validate(id_));
+    EXPECT_TRUE(tm_->IsPresent(id_));
 }
 
 TEST_F(ActionTest, shouldAddSubtask)
@@ -63,7 +63,7 @@ TEST_F(ActionTest, shouldAddSubtask)
     AddSubtaskAction subact{id_, t};
     ActionResult result_subtask = subact.execute(tm_);
     ASSERT_EQ(2, tm_->size());
-    EXPECT_TRUE(tm_->Validate(*result_subtask.id));
+    EXPECT_TRUE(tm_->IsPresent(*result_subtask.id));
     EXPECT_NE(id_, *result_subtask.id);
 
     auto tasks = tm_->getTasks();
@@ -133,7 +133,7 @@ TEST_F(ActionTest, shouldEditTask)
     ActionResult result_edit = act.execute(tm_);
 
     ASSERT_EQ(1, tm_->size());
-    EXPECT_TRUE(tm_->Validate(id_));
+    EXPECT_TRUE(tm_->IsPresent(id_));
     EXPECT_EQ(*result_edit.id, id_);
 
     auto tasks = tm_->getTasks();

--- a/test/ui/IntegrationTest.cpp
+++ b/test/ui/IntegrationTest.cpp
@@ -94,17 +94,17 @@ TEST_F(IntegrationTest, shouldCreateThreeTasksCompleteOneDeleteOne)
 
     Core::TaskID id;
     id.set_value(1);
-    ASSERT_TRUE(tm->Validate(id));
+    ASSERT_TRUE(tm->IsPresent(id));
     EXPECT_EQ(tm->getTasks()[0].id(), id);
     EXPECT_TRUE(tm->getTasks()[0].data().is_complete());
 
     id.set_value(2);
-    ASSERT_TRUE(tm->Validate(id));
+    ASSERT_TRUE(tm->IsPresent(id));
     EXPECT_EQ(tm->getTasks()[1].id(), id);
     EXPECT_FALSE(tm->getTasks()[1].data().is_complete());
 
     id.set_value(3);
-    EXPECT_FALSE(tm->Validate(id));
+    EXPECT_FALSE(tm->IsPresent(id));
 
     EXPECT_EQ(4, tm->gen()->state());
 }
@@ -143,19 +143,19 @@ TEST_F(IntegrationTest, shouldCreateTaskWithSubtasksCompleteAll)
     // check completeness
     Core::TaskID id;
     id.set_value(1);
-    ASSERT_TRUE(tm->Validate(id));
+    ASSERT_TRUE(tm->IsPresent(id));
     EXPECT_EQ(tm->getTasks()[0].id(), id);
     EXPECT_TRUE(tm->getTasks()[0].data().is_complete());
 
     Core::TaskID id2;
     id2.set_value(2);
-    ASSERT_TRUE(tm->Validate(id2));
+    ASSERT_TRUE(tm->IsPresent(id2));
     EXPECT_EQ(tm->getTasks()[1].id(), id2);
     EXPECT_TRUE(tm->getTasks()[1].data().is_complete());
 
     Core::TaskID id3;
     id3.set_value(3);
-    ASSERT_TRUE(tm->Validate(id3));
+    ASSERT_TRUE(tm->IsPresent(id3));
     EXPECT_EQ(tm->getTasks()[2].id(), id3);
     EXPECT_TRUE(tm->getTasks()[2].data().is_complete());
 
@@ -205,17 +205,17 @@ TEST_F(IntegrationTest, shouldCreateTaskWithSubtasksLabelTwo)
     // check labels
     Core::TaskID id;
     id.set_value(1);
-    ASSERT_TRUE(tm->Validate(id));
+    ASSERT_TRUE(tm->IsPresent(id));
     EXPECT_EQ("", tm->getTasks()[0].data().label());
 
     Core::TaskID id2;
     id2.set_value(2);
-    ASSERT_TRUE(tm->Validate(id2));
+    ASSERT_TRUE(tm->IsPresent(id2));
     EXPECT_EQ("l2", tm->getTasks()[1].data().label());
 
     Core::TaskID id3;
     id3.set_value(3);
-    ASSERT_TRUE(tm->Validate(id3));
+    ASSERT_TRUE(tm->IsPresent(id3));
     EXPECT_EQ("l3", tm->getTasks()[2].data().label());
 
     // check parents
@@ -259,11 +259,11 @@ TEST_F(IntegrationTest, shouldCreateThreeTasksDeleteTreeWithConfirm)
 
     Core::TaskID id;
     id.set_value(1);
-    EXPECT_FALSE(tm->Validate(id));
+    EXPECT_FALSE(tm->IsPresent(id));
     id.set_value(2);
-    EXPECT_TRUE(tm->Validate(id));
+    EXPECT_TRUE(tm->IsPresent(id));
     id.set_value(3);
-    EXPECT_FALSE(tm->Validate(id));
+    EXPECT_FALSE(tm->IsPresent(id));
 
     for (int i = 0; i <  prompts.size(); ++i) {
         EXPECT_EQ(prompts[i], prompts_expected[i]);
@@ -311,7 +311,7 @@ TEST_F(IntegrationTest, shouldCreateTaskWithBadInputs)
 
     Core::TaskID id;
     id.set_value(1);
-    EXPECT_TRUE(tm->Validate(id));
+    EXPECT_TRUE(tm->IsPresent(id));
 
     for (int i = 0; i <  prompts.size(); ++i) {
         EXPECT_EQ(prompts[i], prompts_expected[i]);
@@ -392,17 +392,17 @@ TEST_F(IntegrationTest, shouldCreateThreeTasksInAHeirarcySaveAndLoad)
     id2.set_value(2);
     id3.set_value(3);
 
-    ASSERT_TRUE(tm->Validate(id1));
+    ASSERT_TRUE(tm->IsPresent(id1));
     EXPECT_TRUE(tm->getTasks()[0].data().is_complete());
     EXPECT_EQ(tm->getTasks()[0].data().title(), "Task 1");
     EXPECT_FALSE(tm->getTasks()[0].has_parent());
 
-    ASSERT_TRUE(tm->Validate(id2));
+    ASSERT_TRUE(tm->IsPresent(id2));
     EXPECT_TRUE(tm->getTasks()[1].data().is_complete());
     EXPECT_EQ(tm->getTasks()[1].data().title(), "Subtask 2");
     EXPECT_EQ(id1, tm->getTasks()[1].parent());
 
-    ASSERT_TRUE(tm->Validate(id3));
+    ASSERT_TRUE(tm->IsPresent(id3));
     EXPECT_TRUE(tm->getTasks()[2].data().is_complete());
     EXPECT_EQ(tm->getTasks()[2].data().title(), "Subtask 3");
     EXPECT_EQ(id2, tm->getTasks()[2].parent());


### PR DESCRIPTION
Refactoring: eliminate map::at use, better getters for TaskManager class (as per @vladimir-moiseiev comment)