### PR TITLE
Reintroduce missing fixes

### DIFF
--- a/src/model/ModelInterface.h
+++ b/src/model/ModelInterface.h
@@ -21,8 +21,6 @@ public:
     virtual std::vector<Core::TaskEntity> getTasks() const = 0;
     virtual std::vector<Core::TaskEntity> getTasks(const std::string &label) const = 0;
     virtual std::vector<Core::TaskEntity> getTaskWithSubtasks(const Core::TaskID &id) const = 0;
-    virtual std::shared_ptr<IDGenerator> gen() const = 0;
-    virtual size_t size() const = 0;
 
 public:
     virtual ActionResult Add(const Core::Task &) = 0;

--- a/src/model/TaskManager.h
+++ b/src/model/TaskManager.h
@@ -22,8 +22,8 @@ public:
     std::vector<Core::TaskEntity> getTasks() const override;
     std::vector<Core::TaskEntity> getTasks(const std::string &label) const override;
     std::vector<Core::TaskEntity> getTaskWithSubtasks(const Core::TaskID &id) const override;
-    std::shared_ptr<IDGenerator> gen() const override;
-    size_t size() const override;
+    std::shared_ptr<IDGenerator> gen() const;
+    size_t size() const;
 
 public:
     ActionResult Add(const Core::Task &) override;

--- a/src/ui/actions/GetTaskToShowLabelsAction.cpp
+++ b/src/ui/actions/GetTaskToShowLabelsAction.cpp
@@ -8,16 +8,16 @@ GetTaskToShowLabelsAction::GetTaskToShowLabelsAction(const std::string &arg) : a
 }
 
 ActionResult GetTaskToShowLabelsAction::execute(const std::shared_ptr<ModelInterface> &model) {
-    std::optional<Core::TaskID> id{Core::TaskID()};
+    Core::TaskID id;
     try {
-        id->set_value(std::stoi(arg_));
-        if (!model->IsPresent(*id))
+        id.set_value(std::stoi(arg_));
+        if (!model->IsPresent(id))
             return {ActionResult::Status::ID_NOT_FOUND, id};
     } catch (const std::invalid_argument &) {
         return {ActionResult::Status::TAKES_ID, std::nullopt};
     }
 
-    std::vector<Core::TaskEntity> tasks = model->getTaskWithSubtasks(*id);
+    std::vector<Core::TaskEntity> tasks = model->getTaskWithSubtasks(id);
     tasks.erase(tasks.begin() + 1, tasks.end());
     return {ActionResult::Status::SUCCESS, tasks};
 }

--- a/src/ui/actions/GetTaskToShowLabelsAction.cpp
+++ b/src/ui/actions/GetTaskToShowLabelsAction.cpp
@@ -11,13 +11,13 @@ ActionResult GetTaskToShowLabelsAction::execute(const std::shared_ptr<ModelInter
     std::optional<Core::TaskID> id{Core::TaskID()};
     try {
         id->set_value(std::stoi(arg_));
-        if (!model->Validate(*id))
+        if (!model->IsPresent(*id))
             return {ActionResult::Status::ID_NOT_FOUND, id};
     } catch (const std::invalid_argument &) {
         return {ActionResult::Status::TAKES_ID, std::nullopt};
     }
 
-    std::vector<Core::TaskEntity> tasks = model->getTasks(*id);
+    std::vector<Core::TaskEntity> tasks = model->getTaskWithSubtasks(*id);
     tasks.erase(tasks.begin() + 1, tasks.end());
     return {ActionResult::Status::SUCCESS, tasks};
 }

--- a/test/ui/ActionTest.cpp
+++ b/test/ui/ActionTest.cpp
@@ -55,7 +55,7 @@ public:
 
 TEST_F(ActionTest, shouldAddTask)
 {
-    ASSERT_EQ(1, tm_->size());
+    ASSERT_EQ(1, tm_->getTasks().size());
     EXPECT_TRUE(tm_->IsPresent(id_));
 }
 
@@ -66,7 +66,7 @@ TEST_F(ActionTest, shouldAddSubtask)
     t.set_priority(Core::Task::Priority::Task_Priority_MEDIUM);
     AddSubtaskAction subact{id_, t};
     ActionResult result_subtask = subact.execute(tm_);
-    ASSERT_EQ(2, tm_->size());
+    ASSERT_EQ(2, tm_->getTasks().size());
     EXPECT_TRUE(tm_->IsPresent(*result_subtask.id));
     EXPECT_NE(id_, *result_subtask.id);
 
@@ -136,7 +136,7 @@ TEST_F(ActionTest, shouldEditTask)
     EditTaskAction act{id_, t};
     ActionResult result_edit = act.execute(tm_);
 
-    ASSERT_EQ(1, tm_->size());
+    ASSERT_EQ(1, tm_->getTasks().size());
     EXPECT_TRUE(tm_->IsPresent(id_));
     EXPECT_EQ(*result_edit.id, id_);
 
@@ -189,7 +189,7 @@ TEST_F(ActionTest, shouldCompleteTaskWithValidID)
 {
     CompleteTaskAction act{id_};
     ActionResult result_complete = act.execute(tm_);
-    ASSERT_EQ(1, tm_->size());
+    ASSERT_EQ(1, tm_->getTasks().size());
     EXPECT_EQ(result_complete.status, ActionResult::Status::SUCCESS);
     EXPECT_TRUE(tm_->getTasks()[0].data().is_complete());
 }
@@ -200,7 +200,7 @@ TEST_F(ActionTest, shouldNotCompleteTaskWithInvalidID)
     id2.set_value(id_.value()+1);
     CompleteTaskAction act{id2};
     ActionResult result_complete = act.execute(tm_);
-    ASSERT_EQ(1, tm_->size());
+    ASSERT_EQ(1, tm_->getTasks().size());
     EXPECT_EQ(result_complete.status, ActionResult::Status::ID_NOT_FOUND);
     EXPECT_FALSE(tm_->getTasks()[0].data().is_complete());
 }
@@ -212,7 +212,7 @@ TEST_F(ActionTest, shouldUncompleteTaskWithValidID)
 
     UncompleteTaskAction act2{id_};
     ActionResult result_uncomplete = act2.execute(tm_);
-    ASSERT_EQ(1, tm_->size());
+    ASSERT_EQ(1, tm_->getTasks().size());
     EXPECT_EQ(result_uncomplete.status, ActionResult::Status::SUCCESS);
     ASSERT_FALSE(tm_->getTasks()[0].data().is_complete());
 }
@@ -221,7 +221,7 @@ TEST_F(ActionTest, shouldDeleteTaskValidIDNoSubtasks)
 {
     DeleteTaskAction act{id_};
     ActionResult result_delete = act.execute(tm_);
-    EXPECT_EQ(0, tm_->size());
+    EXPECT_EQ(0, tm_->getTasks().size());
     EXPECT_EQ(result_delete.status, ActionResult::Status::SUCCESS);
     EXPECT_EQ(*result_delete.id, id_);
 }
@@ -232,7 +232,7 @@ TEST_F(ActionTest, shouldFailToDeleteTaskWithInvalidID)
     id2.set_value(id_.value()+1);
     DeleteTaskAction act{id2};
     ActionResult result_delete = act.execute(tm_);
-    EXPECT_EQ(1, tm_->size());
+    EXPECT_EQ(1, tm_->getTasks().size());
     EXPECT_EQ(result_delete.status, ActionResult::Status::ID_NOT_FOUND);
     EXPECT_EQ(*result_delete.id, id2);
 }
@@ -241,11 +241,11 @@ TEST_F(ActionTest, shouldDeleteTaskValidIDWithSubtasks)
 {
     AddSubtaskAction add{id_, task_};
     add.execute(tm_);
-    ASSERT_EQ(2, tm_->size());
+    ASSERT_EQ(2, tm_->getTasks().size());
 
     DeleteTaskAction act{id_};
     ActionResult result_delete = act.execute(tm_);
-    ASSERT_EQ(0, tm_->size());
+    ASSERT_EQ(0, tm_->getTasks().size());
     EXPECT_EQ(result_delete.status, ActionResult::Status::SUCCESS);
     EXPECT_EQ(*result_delete.id, id_);
 }
@@ -255,7 +255,7 @@ TEST_F(ActionTest, shouldLabelTask)
     std::string label = "custom";
     LabelTaskAction act{id_, label};
     ActionResult result_label = act.execute(tm_);
-    ASSERT_EQ(1, tm_->size());
+    ASSERT_EQ(1, tm_->getTasks().size());
     EXPECT_EQ(id_, *result_label.id);
     EXPECT_EQ("label", tm_->getTasks()[0].data().labels()[0]);
     EXPECT_EQ(label, tm_->getTasks()[0].data().labels()[1]);
@@ -268,7 +268,7 @@ TEST_F(ActionTest, shouldNotLabelTaskWithInvalidID)
     std::string label = "custom";
     LabelTaskAction act{new_id, label};
     ActionResult result_label = act.execute(tm_);
-    ASSERT_EQ(1, tm_->size());
+    ASSERT_EQ(1, tm_->getTasks().size());
     EXPECT_EQ(result_label.status, ActionResult::Status::ID_NOT_FOUND);
     EXPECT_EQ(new_id, result_label.id);
     EXPECT_EQ("label", tm_->getTasks()[0].data().labels()[0]);
@@ -278,7 +278,7 @@ TEST_F(ActionTest, shouldDoNothing)
 {
     DoNothingAction act;
     ActionResult result = act.execute(tm_);
-    ASSERT_EQ(1, tm_->size());
+    ASSERT_EQ(1, tm_->getTasks().size());
     EXPECT_EQ(result.status, ActionResult::Status::SUCCESS);
     EXPECT_EQ(std::nullopt, result.id);
 
@@ -293,7 +293,7 @@ TEST_F(ActionTest, shouldClearAllLabelsOfTask)
 
     ClearAllLabelsOfTaskAction act{id_};
     ActionResult result = act.execute(tm_);
-    ASSERT_EQ(1, tm_->size());
+    ASSERT_EQ(1, tm_->getTasks().size());
     EXPECT_EQ(result.status, ActionResult::Status::SUCCESS);
     EXPECT_EQ(id_, *result.id);
     auto tasks = tm_->getTaskWithSubtasks(id_);
@@ -309,7 +309,7 @@ TEST_F(ActionTest, shouldClearOneLabelOfTask)
 
     ClearLabelOfTaskAction act{id_, "mylabel2"};
     ActionResult result = act.execute(tm_);
-    ASSERT_EQ(1, tm_->size());
+    ASSERT_EQ(1, tm_->getTasks().size());
     EXPECT_EQ(result.status, ActionResult::Status::SUCCESS);
     EXPECT_EQ(id_, *result.id);
     auto tasks = tm_->getTaskWithSubtasks(id_);
@@ -321,7 +321,7 @@ TEST_F(ActionTest, shouldGetTaskToShowItsLabels)
 {
     GetTaskToShowLabelsAction act{std::to_string(id_.value())};
     ActionResult result = act.execute(tm_);
-    ASSERT_EQ(1, tm_->size());
+    ASSERT_EQ(1, tm_->getTasks().size());
     EXPECT_EQ(result.status, ActionResult::Status::SUCCESS);
     auto tasks = tm_->getTaskWithSubtasks(id_);
     EXPECT_EQ(1, result.tasks.size());
@@ -332,7 +332,7 @@ TEST_F(ActionTest, shouldFailToGetTaskToShowItsLabelsWithInvalidID)
 {
     GetTaskToShowLabelsAction act{std::to_string(id_.value() + 1)};
     ActionResult result = act.execute(tm_);
-    ASSERT_EQ(1, tm_->size());
+    ASSERT_EQ(1, tm_->getTasks().size());
     EXPECT_EQ(result.status, ActionResult::Status::ID_NOT_FOUND);
 }
 
@@ -340,7 +340,7 @@ TEST_F(ActionTest, shouldFailToGetTaskToShowItsLabelsWithInvalidArg)
 {
     GetTaskToShowLabelsAction act{"bad"};
     ActionResult result = act.execute(tm_);
-    ASSERT_EQ(1, tm_->size());
+    ASSERT_EQ(1, tm_->getTasks().size());
     EXPECT_EQ(result.status, ActionResult::Status::TAKES_ID);
     EXPECT_EQ(std::nullopt, result.id);
 }

--- a/test/ui/ActionTest.cpp
+++ b/test/ui/ActionTest.cpp
@@ -296,7 +296,7 @@ TEST_F(ActionTest, shouldClearAllLabelsOfTask)
     ASSERT_EQ(1, tm_->size());
     EXPECT_EQ(result.status, ActionResult::Status::SUCCESS);
     EXPECT_EQ(id_, *result.id);
-    auto tasks = tm_->getTasks(id_);
+    auto tasks = tm_->getTaskWithSubtasks(id_);
     EXPECT_TRUE(tasks[0].data().labels().empty());
 }
 
@@ -312,7 +312,7 @@ TEST_F(ActionTest, shouldClearOneLabelOfTask)
     ASSERT_EQ(1, tm_->size());
     EXPECT_EQ(result.status, ActionResult::Status::SUCCESS);
     EXPECT_EQ(id_, *result.id);
-    auto tasks = tm_->getTasks(id_);
+    auto tasks = tm_->getTaskWithSubtasks(id_);
     EXPECT_EQ(2, tasks[0].data().labels().size());
     EXPECT_EQ("mylabel", tasks[0].data().labels()[1]);
 }
@@ -323,7 +323,7 @@ TEST_F(ActionTest, shouldGetTaskToShowItsLabels)
     ActionResult result = act.execute(tm_);
     ASSERT_EQ(1, tm_->size());
     EXPECT_EQ(result.status, ActionResult::Status::SUCCESS);
-    auto tasks = tm_->getTasks(id_);
+    auto tasks = tm_->getTaskWithSubtasks(id_);
     EXPECT_EQ(1, result.tasks.size());
     EXPECT_EQ(tasks[0], result.tasks[0]);
 }

--- a/test/ui/IntegrationTest.cpp
+++ b/test/ui/IntegrationTest.cpp
@@ -208,17 +208,19 @@ TEST_F(IntegrationTest, shouldCreateTaskWithSubtasksLabelTwo)
     Core::TaskID id;
     id.set_value(1);
     ASSERT_TRUE(tm->IsPresent(id));
-    EXPECT_EQ("", tm->getTasks()[0].data().label());
+    EXPECT_TRUE(tasks[0].data().labels().empty());
 
     Core::TaskID id2;
     id2.set_value(2);
     ASSERT_TRUE(tm->IsPresent(id2));
-    EXPECT_EQ("l2", tm->getTasks()[1].data().label());
+    EXPECT_EQ(1, tasks[1].data().labels().size());
+    EXPECT_EQ("l2", tasks[1].data().labels()[0]);
 
     Core::TaskID id3;
     id3.set_value(3);
     ASSERT_TRUE(tm->IsPresent(id3));
-    EXPECT_EQ("l3", tm->getTasks()[2].data().label());
+    EXPECT_EQ(1, tasks[2].data().labels().size());
+    EXPECT_EQ("l3", tasks[2].data().labels()[0]);
 
     // check parents
     EXPECT_FALSE(tm->getTasks()[0].has_parent());


### PR DESCRIPTION
I though these files were updated at the time of my original TaskManager refactoring merge, but either I forgot, or the changes were lost between different branches and PRs (my bad). 
What was changed: 
• GetTaskToShowLabelsAction was missing renaming of Validate to IsPresent and getTasks to getTaskWithSubtasks
• ActionTest- same renaming 
• IntegrationTest.cpp - label to labels change