### PR TITLE
Removed Factory loop dependency

### DIFF
--- a/src/ui/Factory.cpp
+++ b/src/ui/Factory.cpp
@@ -90,7 +90,7 @@ std::shared_ptr<Step> Factory::createStep(const std::string &command) {
 }
 
 std::shared_ptr<Machine> Factory::createMachine(const State &state) const {
-    return std::make_shared<Machine>(nullptr, Factory::create(reader(), printer()), state);
+    return std::make_shared<Machine>(Factory::create(reader(), printer()), state);
 }
 
 std::shared_ptr<Step> Factory::getNewStep(const State &s) {

--- a/src/ui/Factory.cpp
+++ b/src/ui/Factory.cpp
@@ -89,8 +89,8 @@ std::shared_ptr<Step> Factory::createStep(const std::string &command) {
     }
 }
 
-std::shared_ptr<Machine> Factory::createMachine(const State &state) {
-    return std::make_shared<Machine>(nullptr, shared_from_this(), state);
+std::shared_ptr<Machine> Factory::createMachine(const State &state) const {
+    return std::make_shared<Machine>(nullptr, Factory::create(reader(), printer()), state);
 }
 
 std::shared_ptr<Step> Factory::getNewStep(const State &s) {

--- a/src/ui/Factory.h
+++ b/src/ui/Factory.h
@@ -19,7 +19,7 @@ class Machine;
 class Context;
 class Step;
 
-class Factory : public std::enable_shared_from_this<Factory> {
+class Factory {
 public:
     enum class State{
         HOME,
@@ -56,7 +56,7 @@ public:
     std::shared_ptr<Step> getNewStep(const State &s);
     std::shared_ptr<Step> lazyInitStep(const State &state);
 
-    std::shared_ptr<Machine> createMachine(const State &state);
+    std::shared_ptr<Machine> createMachine(const State &state) const;
 
 public:
     std::shared_ptr<AbstractReader> reader() const;

--- a/src/ui/Machine.cpp
+++ b/src/ui/Machine.cpp
@@ -14,6 +14,10 @@ Machine::Machine(const std::shared_ptr<ModelInterface> &model, const std::shared
         factory_{f}, initial_step_{s}, model_{model} {
 }
 
+Machine::Machine(const std::shared_ptr<Factory> &f, const Factory::State &s) :
+        factory_{f}, initial_step_{s} {
+}
+
 Context Machine::run() {
     return run(context_);
 }

--- a/src/ui/Machine.h
+++ b/src/ui/Machine.h
@@ -15,6 +15,7 @@ class Machine {
 public:
     explicit Machine(const std::shared_ptr<ModelInterface> &model);
     Machine(const std::shared_ptr<ModelInterface> &model, const std::shared_ptr<Factory> &f, const Factory::State &s);
+    Machine(const std::shared_ptr<Factory> &f, const Factory::State &s);
 
 public:
     Context run();

--- a/test/ui/IntegrationTest.cpp
+++ b/test/ui/IntegrationTest.cpp
@@ -62,11 +62,11 @@ private:
 TEST_F(IntegrationTest, shouldCreateThreeTasksCompleteOneDeleteOne)
 {
     auto tm = std::make_shared<TaskManager>();
-    MockReader mr;
-    MockPrinter mp;
-    auto f = Factory::create(std::shared_ptr<AbstractReader>(&mr),
-              std::shared_ptr<AbstractPrinter>(&mp));
-    EXPECT_CALL(mr, read)
+    auto mr = std::make_shared<MockReader>();
+    auto mp = std::make_shared<MockPrinter>();
+    auto f = Factory::create(std::shared_ptr<AbstractReader>(mr),
+              std::shared_ptr<AbstractPrinter>(mp));
+    EXPECT_CALL(*mr, read)
             .Times(17)
             .WillOnce(Return("add"))
             .WillOnce(Return("test 1"))
@@ -86,7 +86,7 @@ TEST_F(IntegrationTest, shouldCreateThreeTasksCompleteOneDeleteOne)
             .WillOnce(Return("Y"))
             .WillOnce(Return("quit"));
 
-    EXPECT_CALL(mp, print)
+    EXPECT_CALL(*mp, print)
             .Times(AtLeast(1));
 
     Machine m(tm, f, Factory::State::HOME);
@@ -113,11 +113,11 @@ TEST_F(IntegrationTest, shouldCreateThreeTasksCompleteOneDeleteOne)
 TEST_F(IntegrationTest, shouldCreateTaskWithSubtasksCompleteAll)
 {
     auto tm = std::make_shared<TaskManager>();
-    MockReader mr;
-    MockPrinter mp;
-    auto f = Factory::create(std::shared_ptr<AbstractReader>(&mr),
-                             std::shared_ptr<AbstractPrinter>(&mp));
-    EXPECT_CALL(*std::dynamic_pointer_cast<MockReader>(f->reader()), read(_))
+    auto mr = std::make_shared<MockReader>();
+    auto mp = std::make_shared<MockPrinter>();
+    auto f = Factory::create(std::shared_ptr<AbstractReader>(mr),
+                             std::shared_ptr<AbstractPrinter>(mp));
+    EXPECT_CALL(*mr, read(_))
             .Times(AtLeast(1))
             .WillOnce(Return("add"))
             .WillOnce(Return("test"))
@@ -134,7 +134,7 @@ TEST_F(IntegrationTest, shouldCreateTaskWithSubtasksCompleteAll)
             .WillOnce(Return("complete 1"))
             .WillOnce(Return("quit"));
 
-    EXPECT_CALL(mp, print(_))
+    EXPECT_CALL(*mp, print(_))
             .Times(AtLeast(1));
 
     Machine m(tm, f, Factory::State::HOME);
@@ -171,11 +171,11 @@ TEST_F(IntegrationTest, shouldCreateTaskWithSubtasksCompleteAll)
 TEST_F(IntegrationTest, shouldCreateTaskWithSubtasksLabelTwo)
 {
     auto tm = std::make_shared<TaskManager>();
-    MockReader mr;
-    MockPrinter mp;
-    auto f = Factory::create(std::shared_ptr<AbstractReader>(&mr),
-                             std::shared_ptr<AbstractPrinter>(&mp));
-    EXPECT_CALL(mr, read)
+    auto mr = std::make_shared<MockReader>();
+    auto mp = std::make_shared<MockPrinter>();
+    auto f = Factory::create(std::shared_ptr<AbstractReader>(mr),
+                             std::shared_ptr<AbstractPrinter>(mp));
+    EXPECT_CALL(*mr, read)
             .Times(AtLeast(1))
             .WillOnce(Return("add"))
             .WillOnce(Return("task 1"))
@@ -196,7 +196,7 @@ TEST_F(IntegrationTest, shouldCreateTaskWithSubtasksLabelTwo)
             .WillOnce(Return("l2"))
             .WillOnce(Return("quit"));
 
-    EXPECT_CALL(mp, print)
+    EXPECT_CALL(*mp, print)
             .Times(AtLeast(1));
 
     Machine m(tm, f, Factory::State::HOME);


### PR DESCRIPTION
Before, when a factory was asked to create a submachine, it inserted a shared_ptr to itself using shared_from_this. This led to original factory never being deleted, as the factory stored steps, some of which stored a submachine, which stored the same factory. Now, they store a copy with the same printer/reader and new cache. The caches store different steps for the top and bottom factories anyway.