### PR TITLE
Label now has tiny type Core::Label, instead of std::string

### DIFF
--- a/proto/Core.proto
+++ b/proto/Core.proto
@@ -18,7 +18,7 @@ message Task {
   Priority priority = 2;
 //  google.protobuf.Timestamp due_date = 3;
   int64  due_date = 3;
-  repeated string labels = 4;
+  repeated Label labels = 4;
   bool is_complete = 5;
 }
 
@@ -29,7 +29,7 @@ message TaskEntity {
 }
 
 message Label {
-  string label = 1;
+  string str = 1;
 }
 
 message ModelRequestResult {

--- a/proto/Service.proto
+++ b/proto/Service.proto
@@ -15,7 +15,7 @@ service TaskManager {
   rpc Complete (Core.TaskID) returns (Core.ModelRequestResult) {}
   rpc Uncomplete (Core.TaskID) returns (Core.ModelRequestResult) {}
   rpc Delete (Core.TaskID) returns (Core.ModelRequestResult) {}
-  rpc IsPresent (Core.TaskID) returns (Core.ModelRequestResult) {}
+  rpc CheckTask (Core.TaskID) returns (Core.ModelRequestResult) {}
   rpc AddLabel (IDWithLabel) returns (Core.ModelRequestResult) {}
   rpc RemoveLabel (IDWithLabel) returns (Core.ModelRequestResult) {}
   rpc RemoveAllLabels (Core.TaskID) returns (Core.ModelRequestResult) {}

--- a/src/model/ModelInterface.h
+++ b/src/model/ModelInterface.h
@@ -28,7 +28,7 @@ public:
     virtual Core::ModelRequestResult Complete(const Core::TaskID &) = 0;
     virtual Core::ModelRequestResult Uncomplete(const Core::TaskID &) = 0;
     virtual Core::ModelRequestResult Delete(const Core::TaskID &, bool deleteChildren) = 0;
-    virtual Core::ModelRequestResult IsPresent(const Core::TaskID &) const = 0;
+    virtual Core::ModelRequestResult CheckTask(const Core::TaskID &) const = 0;
     virtual Core::ModelRequestResult AddLabel(const Core::TaskID &, const Core::Label &label) = 0;
     virtual Core::ModelRequestResult RemoveLabel(const Core::TaskID &, const Core::Label &label) = 0;
     virtual Core::ModelRequestResult RemoveAllLabels(const Core::TaskID &) = 0;

--- a/src/model/ModelInterface.h
+++ b/src/model/ModelInterface.h
@@ -18,7 +18,7 @@ class IDGenerator;
 class ModelInterface {
 public:
     virtual std::vector<Core::TaskEntity> getTasks() const = 0;
-    virtual std::vector<Core::TaskEntity> getTasks(const std::string &label) const = 0;
+    virtual std::vector<Core::TaskEntity> getTasks(const Core::Label &label) const = 0;
     virtual std::vector<Core::TaskEntity> getTaskWithSubtasks(const Core::TaskID &id) const = 0;
 
 public:
@@ -29,8 +29,8 @@ public:
     virtual Core::ModelRequestResult Uncomplete(const Core::TaskID &) = 0;
     virtual Core::ModelRequestResult Delete(const Core::TaskID &, bool deleteChildren) = 0;
     virtual Core::ModelRequestResult IsPresent(const Core::TaskID &) const = 0;
-    virtual Core::ModelRequestResult AddLabel(const Core::TaskID &, const std::string &label) = 0;
-    virtual Core::ModelRequestResult RemoveLabel(const Core::TaskID &, const std::string &label) = 0;
+    virtual Core::ModelRequestResult AddLabel(const Core::TaskID &, const Core::Label &label) = 0;
+    virtual Core::ModelRequestResult RemoveLabel(const Core::TaskID &, const Core::Label &label) = 0;
     virtual Core::ModelRequestResult RemoveAllLabels(const Core::TaskID &) = 0;
 
 public:

--- a/src/model/TaskManager.cpp
+++ b/src/model/TaskManager.cpp
@@ -137,7 +137,7 @@ std::vector<Core::TaskEntity> TaskManager::getTaskWithSubtasks(const Core::TaskI
         for (const auto &ch_id: ChildrenOf(id)) {
             auto ch_tasks = getTaskWithSubtasks(ch_id);
             for (auto &ch_task: ch_tasks) {
-                ch_task.mutable_parent()->CopyFrom(*ParentOf(ch_task.id()));
+                ch_task.set_allocated_parent(std::make_unique<Core::TaskID>(*ParentOf(ch_task.id())).release());
             }
             tasks.insert(tasks.end(), ch_tasks.begin(), ch_tasks.end());
         }

--- a/src/model/TaskManager.h
+++ b/src/model/TaskManager.h
@@ -12,6 +12,7 @@
 #include "utilities/TaskEntityUtils.h"
 #include "utilities/ModelRequestResultUtils.h"
 #include "utilities/NodeUtils.h"
+#include "utilities/LabelUtils.h"
 #include "ModelInterface.h"
 #include "IDGenerator.h"
 #include "Node.h"
@@ -23,7 +24,7 @@ public:
 
 public:
     std::vector<Core::TaskEntity> getTasks() const override;
-    std::vector<Core::TaskEntity> getTasks(const std::string &label) const override;
+    std::vector<Core::TaskEntity> getTasks(const Core::Label &label) const override;
     std::vector<Core::TaskEntity> getTaskWithSubtasks(const Core::TaskID &id) const override;
     std::shared_ptr<IDGenerator> gen() const;
     size_t size() const;
@@ -36,8 +37,8 @@ public:
     Core::ModelRequestResult Uncomplete(const Core::TaskID &) override;
     Core::ModelRequestResult Delete(const Core::TaskID &id, bool deleteChildren) override;
     Core::ModelRequestResult IsPresent(const Core::TaskID &id) const override;
-    Core::ModelRequestResult AddLabel(const Core::TaskID &, const std::string &) override;
-    Core::ModelRequestResult RemoveLabel(const Core::TaskID &, const std::string &) override;
+    Core::ModelRequestResult AddLabel(const Core::TaskID &, const Core::Label &) override;
+    Core::ModelRequestResult RemoveLabel(const Core::TaskID &, const Core::Label &) override;
     Core::ModelRequestResult RemoveAllLabels(const Core::TaskID &) override;
 
 public:

--- a/src/model/TaskManager.h
+++ b/src/model/TaskManager.h
@@ -36,7 +36,7 @@ public:
     Core::ModelRequestResult Complete(const Core::TaskID &) override;
     Core::ModelRequestResult Uncomplete(const Core::TaskID &) override;
     Core::ModelRequestResult Delete(const Core::TaskID &id, bool deleteChildren) override;
-    Core::ModelRequestResult IsPresent(const Core::TaskID &id) const override;
+    Core::ModelRequestResult CheckTask(const Core::TaskID &id) const override;
     Core::ModelRequestResult AddLabel(const Core::TaskID &, const Core::Label &) override;
     Core::ModelRequestResult RemoveLabel(const Core::TaskID &, const Core::Label &) override;
     Core::ModelRequestResult RemoveAllLabels(const Core::TaskID &) override;

--- a/src/transport/TaskManagerGRPCClient.cpp
+++ b/src/transport/TaskManagerGRPCClient.cpp
@@ -51,8 +51,8 @@ Core::ModelRequestResult TaskManagerGRPCClient::Add(const Core::Task& request) {
 
 Core::ModelRequestResult TaskManagerGRPCClient::AddSubtask(const Core::Task& task, const Core::TaskID &id) {
     Core::TaskEntity request;
-    request.mutable_id()->CopyFrom(id);
-    request.mutable_data()->CopyFrom(task);
+    request.set_allocated_id(std::make_unique<Core::TaskID>(id).release());
+    request.set_allocated_data(std::make_unique<Core::Task>(task).release());
     Core::ModelRequestResult reply;
     grpc::ClientContext context;
     grpc::Status status = stub_->AddSubtask(&context, request, &reply);
@@ -62,8 +62,8 @@ Core::ModelRequestResult TaskManagerGRPCClient::AddSubtask(const Core::Task& tas
 
 Core::ModelRequestResult TaskManagerGRPCClient::Edit(const Core::TaskID &id, const Core::Task& task) {
     Core::TaskEntity request;
-    request.mutable_id()->CopyFrom(id);
-    request.mutable_data()->CopyFrom(task);
+    request.set_allocated_id(std::make_unique<Core::TaskID>(id).release());
+    request.set_allocated_data(std::make_unique<Core::Task>(task).release());
     Core::ModelRequestResult reply;
     grpc::ClientContext context;
     grpc::Status status = stub_->Edit(&context, request, &reply);
@@ -105,8 +105,8 @@ Core::ModelRequestResult TaskManagerGRPCClient::CheckTask(const Core::TaskID &re
 
 Core::ModelRequestResult TaskManagerGRPCClient::AddLabel(const Core::TaskID &id, const Core::Label &label) {
     Transfer::IDWithLabel request;
-    request.mutable_id()->CopyFrom(id);
-    request.mutable_label()->CopyFrom(label);
+    request.set_allocated_id(std::make_unique<Core::TaskID>(id).release());
+    request.set_allocated_label(std::make_unique<Core::Label>(label).release());
     Core::ModelRequestResult reply;
     grpc::ClientContext context;
     grpc::Status status = stub_->AddLabel(&context, request, &reply);
@@ -116,8 +116,8 @@ Core::ModelRequestResult TaskManagerGRPCClient::AddLabel(const Core::TaskID &id,
 
 Core::ModelRequestResult TaskManagerGRPCClient::RemoveLabel(const Core::TaskID &id, const Core::Label &label) {
     Transfer::IDWithLabel request;
-    request.mutable_id()->CopyFrom(id);
-    request.mutable_label()->CopyFrom(label);
+    request.set_allocated_id(std::make_unique<Core::TaskID>(id).release());
+    request.set_allocated_label(std::make_unique<Core::Label>(label).release());
     Core::ModelRequestResult reply;
     grpc::ClientContext context;
     grpc::Status status = stub_->RemoveLabel(&context, request, &reply);

--- a/src/transport/TaskManagerGRPCClient.cpp
+++ b/src/transport/TaskManagerGRPCClient.cpp
@@ -95,10 +95,10 @@ Core::ModelRequestResult TaskManagerGRPCClient::Delete(const Core::TaskID &reque
     return reply;
 }
 
-Core::ModelRequestResult TaskManagerGRPCClient::IsPresent(const Core::TaskID &request) const {
+Core::ModelRequestResult TaskManagerGRPCClient::CheckTask(const Core::TaskID &request) const {
     Core::ModelRequestResult reply;
     grpc::ClientContext context;
-    grpc::Status status = stub_->IsPresent(&context, request, &reply);
+    grpc::Status status = stub_->CheckTask(&context, request, &reply);
 
     return reply;
 }

--- a/src/transport/TaskManagerGRPCClient.cpp
+++ b/src/transport/TaskManagerGRPCClient.cpp
@@ -25,12 +25,10 @@ std::vector<Core::TaskEntity> TaskManagerGRPCClient::getTasks() const {
     return ToTaskEntitiesVector(reply);
 }
 
-std::vector<Core::TaskEntity> TaskManagerGRPCClient::getTasks(const std::string &label) const {
-    Core::Label request;
-    request.set_label(label);
+std::vector<Core::TaskEntity> TaskManagerGRPCClient::getTasks(const Core::Label &label) const {
     Transfer::ManyTaskEntities reply;
     grpc::ClientContext context;
-    grpc::Status status = stub_->getTasksByLabel(&context, request, &reply);
+    grpc::Status status = stub_->getTasksByLabel(&context, label, &reply);
 
     return ToTaskEntitiesVector(reply);
 }
@@ -105,10 +103,10 @@ Core::ModelRequestResult TaskManagerGRPCClient::IsPresent(const Core::TaskID &re
     return reply;
 }
 
-Core::ModelRequestResult TaskManagerGRPCClient::AddLabel(const Core::TaskID &id, const std::string &label) {
+Core::ModelRequestResult TaskManagerGRPCClient::AddLabel(const Core::TaskID &id, const Core::Label &label) {
     Transfer::IDWithLabel request;
     request.mutable_id()->CopyFrom(id);
-    request.mutable_label()->set_label(label);
+    request.mutable_label()->CopyFrom(label);
     Core::ModelRequestResult reply;
     grpc::ClientContext context;
     grpc::Status status = stub_->AddLabel(&context, request, &reply);
@@ -116,10 +114,10 @@ Core::ModelRequestResult TaskManagerGRPCClient::AddLabel(const Core::TaskID &id,
     return reply;
 }
 
-Core::ModelRequestResult TaskManagerGRPCClient::RemoveLabel(const Core::TaskID &id, const std::string &label) {
+Core::ModelRequestResult TaskManagerGRPCClient::RemoveLabel(const Core::TaskID &id, const Core::Label &label) {
     Transfer::IDWithLabel request;
     request.mutable_id()->CopyFrom(id);
-    request.mutable_label()->set_label(label);
+    request.mutable_label()->CopyFrom(label);
     Core::ModelRequestResult reply;
     grpc::ClientContext context;
     grpc::Status status = stub_->RemoveLabel(&context, request, &reply);

--- a/src/transport/TaskManagerGRPCClient.h
+++ b/src/transport/TaskManagerGRPCClient.h
@@ -17,7 +17,7 @@ public:
 
 public:
     std::vector<Core::TaskEntity> getTasks() const override;
-    std::vector<Core::TaskEntity> getTasks(const std::string &label) const override;
+    std::vector<Core::TaskEntity> getTasks(const Core::Label &label) const override;
     std::vector<Core::TaskEntity> getTaskWithSubtasks(const Core::TaskID &id) const override;
 
 public:
@@ -28,8 +28,8 @@ public:
     Core::ModelRequestResult Uncomplete(const Core::TaskID &) override;
     Core::ModelRequestResult Delete(const Core::TaskID &, bool deleteChildren) override;
     Core::ModelRequestResult IsPresent(const Core::TaskID &) const override;
-    Core::ModelRequestResult AddLabel(const Core::TaskID &, const std::string &label) override;
-    Core::ModelRequestResult RemoveLabel(const Core::TaskID &, const std::string &label) override;
+    Core::ModelRequestResult AddLabel(const Core::TaskID &, const Core::Label &label) override;
+    Core::ModelRequestResult RemoveLabel(const Core::TaskID &, const Core::Label &label) override;
     Core::ModelRequestResult RemoveAllLabels(const Core::TaskID &) override;
 
 public:

--- a/src/transport/TaskManagerGRPCClient.h
+++ b/src/transport/TaskManagerGRPCClient.h
@@ -27,7 +27,7 @@ public:
     Core::ModelRequestResult Complete(const Core::TaskID &) override;
     Core::ModelRequestResult Uncomplete(const Core::TaskID &) override;
     Core::ModelRequestResult Delete(const Core::TaskID &, bool deleteChildren) override;
-    Core::ModelRequestResult IsPresent(const Core::TaskID &) const override;
+    Core::ModelRequestResult CheckTask(const Core::TaskID &) const override;
     Core::ModelRequestResult AddLabel(const Core::TaskID &, const Core::Label &label) override;
     Core::ModelRequestResult RemoveLabel(const Core::TaskID &, const Core::Label &label) override;
     Core::ModelRequestResult RemoveAllLabels(const Core::TaskID &) override;

--- a/src/transport/TaskManagerGRPCService.cpp
+++ b/src/transport/TaskManagerGRPCService.cpp
@@ -76,10 +76,10 @@ grpc::Status TaskManagerGRPCService::Delete(grpc::ServerContext* context,
     return grpc::Status::OK;
 }
 
-grpc::Status TaskManagerGRPCService::IsPresent(grpc::ServerContext* context,
+grpc::Status TaskManagerGRPCService::CheckTask(grpc::ServerContext* context,
                                                const Core::TaskID* id,
                                                Core::ModelRequestResult* result) {
-    *result = model_->IsPresent(*id);
+    *result = model_->CheckTask(*id);
     return grpc::Status::OK;
 }
 

--- a/src/transport/TaskManagerGRPCService.cpp
+++ b/src/transport/TaskManagerGRPCService.cpp
@@ -24,7 +24,7 @@ grpc::Status TaskManagerGRPCService::getTasks(grpc::ServerContext* context,
 grpc::Status TaskManagerGRPCService::getTasksByLabel(grpc::ServerContext* context,
                                                      const Core::Label* label,
                                                      Transfer::ManyTaskEntities* result) {
-    *result = ToManyTaskEntities(model_->getTasks(label->label()));
+    *result = ToManyTaskEntities(model_->getTasks(*label));
     return grpc::Status::OK;
 }
 
@@ -86,14 +86,14 @@ grpc::Status TaskManagerGRPCService::IsPresent(grpc::ServerContext* context,
 grpc::Status TaskManagerGRPCService::AddLabel(grpc::ServerContext* context,
                                               const Transfer::IDWithLabel* msg,
                                               Core::ModelRequestResult* result) {
-    *result = model_->AddLabel(msg->id(), msg->label().label());
+    *result = model_->AddLabel(msg->id(), msg->label());
     return grpc::Status::OK;
 }
 
 grpc::Status TaskManagerGRPCService::RemoveLabel(grpc::ServerContext* context,
                                                 const Transfer::IDWithLabel* msg,
                                                 Core::ModelRequestResult* result) {
-    *result = model_->RemoveLabel(msg->id(), msg->label().label());
+    *result = model_->RemoveLabel(msg->id(), msg->label());
     return grpc::Status::OK;
 }
 

--- a/src/transport/TaskManagerGRPCService.h
+++ b/src/transport/TaskManagerGRPCService.h
@@ -32,8 +32,8 @@ public:
                      Core::ModelRequestResult* result) override;
     grpc::Status Delete(grpc::ServerContext* context, const Core::TaskID* id,
                      Core::ModelRequestResult* result) override;
-    grpc::Status IsPresent(grpc::ServerContext* context, const Core::TaskID* id,
-                     Core::ModelRequestResult* result) override;
+    grpc::Status CheckTask(grpc::ServerContext* context, const Core::TaskID* id,
+                           Core::ModelRequestResult* result) override;
     grpc::Status AddLabel(grpc::ServerContext* context, const Transfer::IDWithLabel* msg,
                      Core::ModelRequestResult* result) override;
     grpc::Status RemoveLabel(grpc::ServerContext* context, const Transfer::IDWithLabel* msg,

--- a/src/ui/actions/ClearLabelOfTaskAction.cpp
+++ b/src/ui/actions/ClearLabelOfTaskAction.cpp
@@ -5,7 +5,7 @@
 #include "ClearLabelOfTaskAction.h"
 #include "ui/Context.h"
 
-ClearLabelOfTaskAction::ClearLabelOfTaskAction(const Core::TaskID &id, const std::string &label) :
+ClearLabelOfTaskAction::ClearLabelOfTaskAction(const Core::TaskID &id, const Core::Label &label) :
         id_{id}, label_{label} {
 }
 

--- a/src/ui/actions/ClearLabelOfTaskAction.h
+++ b/src/ui/actions/ClearLabelOfTaskAction.h
@@ -9,14 +9,14 @@
 
 class ClearLabelOfTaskAction : public Action {
 public:
-    explicit ClearLabelOfTaskAction(const Core::TaskID &, const std::string &label);
+    explicit ClearLabelOfTaskAction(const Core::TaskID &, const Core::Label &label);
 
 public:
     ActionResult execute(const std::shared_ptr<ModelInterface> &) override;
 
 private:
     Core::TaskID id_;
-    std::string label_;
+    Core::Label label_;
 };
 
 

--- a/src/ui/actions/GetTaskToShowByIDAction.cpp
+++ b/src/ui/actions/GetTaskToShowByIDAction.cpp
@@ -9,7 +9,7 @@ GetTaskToShowByIDAction::GetTaskToShowByIDAction(const Core::TaskID &id) : id_{i
 }
 
 ActionResult GetTaskToShowByIDAction::execute(const std::shared_ptr<ModelInterface> &model) {
-    auto check = model->IsPresent(id_);
+    auto check = model->CheckTask(id_);
     if (!ToBool(check))
         return check;
 

--- a/src/ui/actions/GetTaskToShowLabelsAction.cpp
+++ b/src/ui/actions/GetTaskToShowLabelsAction.cpp
@@ -11,7 +11,7 @@ GetTaskToShowLabelsAction::GetTaskToShowLabelsAction(const std::optional<Core::T
 ActionResult GetTaskToShowLabelsAction::execute(const std::shared_ptr<ModelInterface> &model) {
     Core::ModelRequestResult result;
     if (id_) {
-        auto check = model->IsPresent(*id_);
+        auto check = model->CheckTask(*id_);
         if (!ToBool(check))
             return check;
     } else {

--- a/src/ui/actions/GetTasksToShowByLabelAction.cpp
+++ b/src/ui/actions/GetTasksToShowByLabelAction.cpp
@@ -4,7 +4,7 @@
 
 #include "GetTasksToShowByLabelAction.h"
 
-GetTasksToShowByLabelAction::GetTasksToShowByLabelAction(const std::string &label) : label_{label} {
+GetTasksToShowByLabelAction::GetTasksToShowByLabelAction(const Core::Label &label) : label_{label} {
 }
 
 ActionResult GetTasksToShowByLabelAction::execute(const std::shared_ptr<ModelInterface> &model) {

--- a/src/ui/actions/GetTasksToShowByLabelAction.h
+++ b/src/ui/actions/GetTasksToShowByLabelAction.h
@@ -9,13 +9,13 @@
 
 class GetTasksToShowByLabelAction : public Action {
 public:
-    explicit GetTasksToShowByLabelAction(const std::string &label);
+    explicit GetTasksToShowByLabelAction(const Core::Label &label);
 
 public:
     ActionResult execute(const std::shared_ptr<ModelInterface> &) override;
 
 private:
-    std::string label_;
+    Core::Label label_;
 };
 
 

--- a/src/ui/actions/LabelTaskAction.cpp
+++ b/src/ui/actions/LabelTaskAction.cpp
@@ -3,9 +3,8 @@
 //
 
 #include "LabelTaskAction.h"
-#include "ui/Context.h"
 
-LabelTaskAction::LabelTaskAction(const Core::TaskID &id, const std::string &label) :
+LabelTaskAction::LabelTaskAction(const Core::TaskID &id, const Core::Label &label) :
                  id_{id}, label_{label} {
 }
 

--- a/src/ui/actions/LabelTaskAction.h
+++ b/src/ui/actions/LabelTaskAction.h
@@ -9,14 +9,14 @@
 
 class LabelTaskAction : public Action {
 public:
-    explicit LabelTaskAction(const Core::TaskID &, const std::string &label);
+    explicit LabelTaskAction(const Core::TaskID &, const Core::Label &label);
 
 public:
     ActionResult execute(const std::shared_ptr<ModelInterface> &) override;
 
 private:
     Core::TaskID id_;
-    std::string label_;
+    Core::Label label_;
 };
 
 

--- a/src/ui/actions/ValidateIDAction.cpp
+++ b/src/ui/actions/ValidateIDAction.cpp
@@ -11,7 +11,7 @@ ValidateIDAction::ValidateIDAction(const std::optional<Core::TaskID> &id) : id_{
 ActionResult ValidateIDAction::execute(const std::shared_ptr<ModelInterface> &model) {
     Core::ModelRequestResult result;
     if (id_) {
-        return model->IsPresent(*id_);
+        return model->CheckTask(*id_);
     } else {
         result.set_status(Core::ModelRequestResult_Status_TAKES_ID);
         return result;

--- a/src/ui/steps/ClearLabelStep.cpp
+++ b/src/ui/steps/ClearLabelStep.cpp
@@ -11,8 +11,8 @@ ClearLabelStep::ClearLabelStep(const std::shared_ptr<AbstractReader> &reader,
 }
 
 std::unique_ptr<Action> ClearLabelStep::genAction(Context &context) {
-    std::string label = readLabel();
-    return std::unique_ptr<Action>(new ClearLabelOfTaskAction(*context.id(), label));
+    auto label = readLabel();
+    return std::make_unique<ClearLabelOfTaskAction>(*context.id(), label);
 }
 
 std::shared_ptr<Step> ClearLabelStep::genNextStep(const ActionResult &result, const std::shared_ptr<Factory> &factory) {
@@ -20,9 +20,11 @@ std::shared_ptr<Step> ClearLabelStep::genNextStep(const ActionResult &result, co
 
 }
 
-std::string ClearLabelStep::readLabel() const {
-    std::string label = reader()->read("[Clear Label]\n    >> ");
-    while (label.empty())
-        label = reader()->read("Label cannot be empty. Try again.\n    >> ");
+Core::Label ClearLabelStep::readLabel() const {
+    Core::Label label;
+    std::string str = reader()->read("[Clear Label]\n    >> ");
+    while (str.empty())
+        str = reader()->read("Label cannot be empty. Try again.\n    >> ");
+    label.set_str(str);
     return label;
 }

--- a/src/ui/steps/ClearLabelStep.h
+++ b/src/ui/steps/ClearLabelStep.h
@@ -18,7 +18,7 @@ public:
     std::shared_ptr<Step> genNextStep(const ActionResult &, const std::shared_ptr<Factory> &) override;
 
 public:
-    std::string readLabel() const;
+    Core::Label readLabel() const;
 };
 
 

--- a/src/ui/steps/HomeStep.cpp
+++ b/src/ui/steps/HomeStep.cpp
@@ -30,8 +30,11 @@ std::unique_ptr<Action> HomeStep::genAction(Context &) {
             return std::make_unique<GetTaskToShowByIDAction>(*id);
         else if (arg.empty())
             return std::make_unique<GetAllTasksToShowAction>();
-        else
-            return std::make_unique<GetTasksToShowByLabelAction>(arg);
+        else {
+            Core::Label label;
+            label.set_str(arg);
+            return std::make_unique<GetTasksToShowByLabelAction>(label);
+        }
     } else if (command_ == "labels") {
         return std::make_unique<GetTaskToShowLabelsAction>(id);
     } else if (command_ == "save") {

--- a/src/ui/steps/LabelStep.cpp
+++ b/src/ui/steps/LabelStep.cpp
@@ -11,8 +11,8 @@ LabelStep::LabelStep(const std::shared_ptr<AbstractReader> &reader,
 }
 
 std::unique_ptr<Action> LabelStep::genAction(Context &context) {
-    std::string label = readLabel();
-    return std::unique_ptr<Action>(new LabelTaskAction(*context.id(), label));
+    auto label = readLabel();
+    return std::make_unique<LabelTaskAction>(*context.id(), label);
 }
 
 std::shared_ptr<Step> LabelStep::genNextStep(const ActionResult &result, const std::shared_ptr<Factory> &factory) {
@@ -20,9 +20,11 @@ std::shared_ptr<Step> LabelStep::genNextStep(const ActionResult &result, const s
 
 }
 
-std::string LabelStep::readLabel() const {
-    std::string label = reader()->read("[Add Label]\n    >> ");
-    while (label.empty())
-        label = reader()->read("Label cannot be empty. Try again.\n    >> ");
+Core::Label LabelStep::readLabel() const {
+    Core::Label label;
+    std::string str = reader()->read("[Clear Label]\n    >> ");
+    while (str.empty())
+        str = reader()->read("Label cannot be empty. Try again.\n    >> ");
+    label.set_str(str);
     return label;
 }

--- a/src/ui/steps/LabelStep.h
+++ b/src/ui/steps/LabelStep.h
@@ -17,7 +17,7 @@ public:
     std::shared_ptr<Step> genNextStep(const ActionResult &, const std::shared_ptr<Factory> &) override;
 
 public:
-    std::string readLabel() const;
+    Core::Label readLabel() const;
 };
 
 

--- a/src/ui/steps/ShowAllLabelsStep.cpp
+++ b/src/ui/steps/ShowAllLabelsStep.cpp
@@ -14,7 +14,7 @@ std::unique_ptr<Action> ShowAllLabelsStep::genAction(Context &context) {
     if (!context.tasks().empty()) {
         auto labels = context.tasks()[0].data().labels();
         for (int i = 0; i < labels.size(); ++i) {
-            os << labels[i];
+            os << labels[i].str();
             if (i < labels.size()-1)
                 os << ", ";
         }

--- a/src/utilities/LabelUtils.cpp
+++ b/src/utilities/LabelUtils.cpp
@@ -1,0 +1,27 @@
+//
+// Created by Anton O. on 2/21/22.
+//
+
+#include "LabelUtils.h"
+
+bool Core::operator==(const Core::Label &lhs, const Core::Label &rhs) {
+    return lhs.str() == rhs.str();
+}
+
+bool Core::operator!=(const Core::Label &lhs, const Core::Label &rhs) {
+    return lhs.str() != rhs.str();
+}
+
+bool Core::operator==(const ::google::protobuf::RepeatedPtrField<Core::Label> &lhs,
+                const ::google::protobuf::RepeatedPtrField<Core::Label> &rhs) {
+    if (lhs.size() == rhs.size()) {
+        for (int i = 0; i < lhs.size(); ++i) {
+            if (lhs[i] != rhs[i])
+                return false;
+        }
+    } else {
+        return false;
+    }
+
+    return true;
+}

--- a/src/utilities/LabelUtils.h
+++ b/src/utilities/LabelUtils.h
@@ -1,0 +1,18 @@
+//
+// Created by Anton O. on 2/21/22.
+//
+
+#ifndef TASKMANAGER_SRC_UTILITIES_LABELUTILS_H_
+#define TASKMANAGER_SRC_UTILITIES_LABELUTILS_H_
+
+#include "Core.pb.h"
+
+namespace Core {
+    bool operator==(const Core::Label &lhs, const Core::Label &rhs);
+    bool operator!=(const Core::Label &lhs, const Core::Label &rhs);
+    bool operator==(const ::google::protobuf::RepeatedPtrField<Core::Label> &lhs,
+                    const ::google::protobuf::RepeatedPtrField<Core::Label> &rhs);
+};
+
+
+#endif //TASKMANAGER_SRC_UTILITIES_LABELUTILS_H_

--- a/src/utilities/TaskEntityUtils.cpp
+++ b/src/utilities/TaskEntityUtils.cpp
@@ -18,15 +18,15 @@ Core::TaskEntity  Core::createTaskEntity(const Core::TaskID &id,
                                         const Core::Task &task,
                                         const Core::TaskID &parent_id) {
     Core::TaskEntity te;
-    te.mutable_id()->CopyFrom(id);
-    te.mutable_data()->CopyFrom(task);
-    te.mutable_parent()->CopyFrom(parent_id);
+    te.set_allocated_id(std::make_unique<Core::TaskID>(id).release());
+    te.set_allocated_data(std::make_unique<Core::Task>(task).release());
+    te.set_allocated_parent(std::make_unique<Core::TaskID>(parent_id).release());
     return te;
 }
 Core::TaskEntity  Core::createTaskEntity(const Core::TaskID &id,
                                          const Core::Task &task) {
     Core::TaskEntity te;
-    te.mutable_id()->CopyFrom(id);
-    te.mutable_data()->CopyFrom(task);
+    te.set_allocated_id(std::make_unique<Core::TaskID>(id).release());
+    te.set_allocated_data(std::make_unique<Core::Task>(task).release());
     return te;
 }

--- a/src/utilities/TaskEntityUtils.h
+++ b/src/utilities/TaskEntityUtils.h
@@ -7,6 +7,7 @@
 
 #include "Core.pb.h"
 #include "TaskUtils.h"
+#include "LabelUtils.h"
 
 namespace Core {
 bool operator==(const Core::TaskEntity &lhs, const Core::TaskEntity &rhs);

--- a/src/utilities/TaskUtils.cpp
+++ b/src/utilities/TaskUtils.cpp
@@ -60,7 +60,26 @@ Core::Task Core::createTask(const std::string &title,
     t.set_title(title);
     t.set_priority(priority);
     t.set_due_date(due_date);
-    t.add_labels(label);
+    if (!label.empty()) {
+        auto label_ptr = std::make_unique<Core::Label>();
+        label_ptr->set_str(label);
+        t.mutable_labels()->AddAllocated(label_ptr.release());
+    }
+    t.set_is_complete(is_complete);
+    return t;
+}
+
+Core::Task Core::createTask(const std::string &title,
+                            const Core::Task::Priority &priority,
+                            const time_t &due_date,
+                            const Core::Label &label,
+                            bool is_complete) {
+    Core::Task t;
+    t.set_title(title);
+    t.set_priority(priority);
+    t.set_due_date(due_date);
+    if (!label.str().empty())
+        t.mutable_labels()->AddAllocated(std::make_unique<Core::Label>(label).release());
     t.set_is_complete(is_complete);
     return t;
 }

--- a/src/utilities/TaskUtils.h
+++ b/src/utilities/TaskUtils.h
@@ -7,6 +7,7 @@
 
 #include <sstream>
 #include "Core.pb.h"
+#include "LabelUtils.h"
 
 typedef ::google::protobuf::RepeatedPtrField<std::string> repStr;
 
@@ -18,6 +19,12 @@ Core::Task createTask(const std::string &title,
                       const Core::Task::Priority &priority,
                       const time_t &due_date,
                       const std::string &label,
+                      bool is_complete);
+
+Core::Task createTask(const std::string &title,
+                      const Core::Task::Priority &priority,
+                      const time_t &due_date,
+                      const Core::Label &label,
                       bool is_complete);
 }
 std::string to_string(const Core::Task &t);

--- a/test/model/DISABLED_TaskManagerStressTest.cpp
+++ b/test/model/DISABLED_TaskManagerStressTest.cpp
@@ -122,7 +122,7 @@ std::vector<Core::TaskEntity> runCommand(const Command &command, TaskManager &tm
             tm.Delete(getRandomID(tm), true);
             break;
         case Command::IS_PRESENT:
-            tm.IsPresent(id);
+            tm.CheckTask(id);
             break;
         case Command::LABEL:
             tm.AddLabel(getRandomID(tm), getRandomLabel());

--- a/test/model/DISABLED_TaskManagerStressTest.cpp
+++ b/test/model/DISABLED_TaskManagerStressTest.cpp
@@ -62,10 +62,12 @@ Core::TaskID getRandomID(const TaskManager &tm) {
     }
 }
 
-std::string getRandomLabel() {
+Core::Label getRandomLabel() {
+    Core::Label label;
     std::uniform_int_distribution<int> uni(0, 50); // guaranteed unbiased
     auto random_integer = uni(rng);
-    return std::to_string(random_integer);
+    label.set_str(std::to_string(random_integer));
+    return label;
 }
 
 std::vector<Core::TaskEntity> runCommand(const Command &command, TaskManager &tm) {

--- a/test/model/TaskManagerTest.cpp
+++ b/test/model/TaskManagerTest.cpp
@@ -47,7 +47,7 @@ TEST_F(TaskManagerTest, shouldAddTask)
     ASSERT_TRUE(result.has_id());
     const Core::TaskID& id = result.id();
     ASSERT_EQ(1, tm.size());
-    EXPECT_TRUE(ToBool(tm.IsPresent(id)));
+    EXPECT_TRUE(ToBool(tm.CheckTask(id)));
 }
 
 TEST_F(TaskManagerTest, shouldFailToAddSubtaskWithMissingParent)
@@ -75,8 +75,8 @@ TEST_F(TaskManagerTest, shouldAddSubtask)
     const auto& id_ch = subtask_result.id();
 
     ASSERT_EQ(2, tm.size());
-    EXPECT_TRUE(ToBool(tm.IsPresent(id)));
-    EXPECT_TRUE(ToBool(tm.IsPresent(id_ch)));
+    EXPECT_TRUE(ToBool(tm.CheckTask(id)));
+    EXPECT_TRUE(ToBool(tm.CheckTask(id_ch)));
     EXPECT_EQ(id, tm.getTasks()[1].parent());
 }
 
@@ -113,7 +113,7 @@ TEST_F(TaskManagerTest, shouldDeleteTask)
     ASSERT_TRUE(result.has_id());
     const auto& id = result.id();
     tm.Delete(id, false);
-    EXPECT_FALSE(ToBool(tm.IsPresent(id)));
+    EXPECT_FALSE(ToBool(tm.CheckTask(id)));
 }
 
 TEST_F(TaskManagerTest, shouldFailToDeleteTaskWithWrongID)

--- a/test/transfer/TaskManagerClinetTest.cpp
+++ b/test/transfer/TaskManagerClinetTest.cpp
@@ -227,7 +227,7 @@ TEST_F(TaskManagerGRPCClientTest, shouldSendIsPresentRequest)
 {
     auto stub = std::make_unique<MockTaskManagerStub>();
 
-    EXPECT_CALL(*stub, IsPresent(_, id_, _))
+    EXPECT_CALL(*stub, CheckTask(_, id_, _))
             .WillOnce(testing::Invoke(
                     [this] (ClientContext*, const TaskID &request, Core::ModelRequestResult* reply) -> grpc::Status {
                         reply->set_allocated_id(std::make_unique<Core::TaskID>(id_).release());
@@ -235,7 +235,7 @@ TEST_F(TaskManagerGRPCClientTest, shouldSendIsPresentRequest)
                     }));
 
     TaskManagerGRPCClient client{std::move(stub)};
-    Core::ModelRequestResult result = client.IsPresent(id_);
+    Core::ModelRequestResult result = client.CheckTask(id_);
     ASSERT_TRUE(result.has_id());
     EXPECT_EQ(result.id(), id_);
 }

--- a/test/transfer/TaskManagerClinetTest.cpp
+++ b/test/transfer/TaskManagerClinetTest.cpp
@@ -41,8 +41,8 @@ public:
                                  false);
         task_.set_is_complete(false);
         id_.set_value(42);
-        entity_.mutable_id()->CopyFrom(id_);
-        entity_.mutable_data()->CopyFrom(task_);
+        entity_.set_allocated_id(std::make_unique<Core::TaskID>(id_).release());
+        entity_.set_allocated_data(std::make_unique<Core::Task>(task_).release());
     }
 };
 
@@ -244,10 +244,10 @@ TEST_F(TaskManagerGRPCClientTest, shouldSendAddLabelRequest)
 {
     auto stub = std::make_unique<MockTaskManagerStub>();
     IDWithLabel request;
-    request.mutable_id()->CopyFrom(id_);
+    request.set_allocated_id(std::make_unique<Core::TaskID>(id_).release());
     Core::Label new_label;
     new_label.set_str("new_label");
-    request.mutable_label()->CopyFrom(new_label);
+    request.set_allocated_label(std::make_unique<Core::Label>(new_label).release());
 
     EXPECT_CALL(*stub, AddLabel(_, request, _))
             .WillOnce(testing::Invoke(
@@ -266,10 +266,10 @@ TEST_F(TaskManagerGRPCClientTest, shouldSendRemoveLabelRequest)
 {
     auto stub = std::make_unique<MockTaskManagerStub>();
     IDWithLabel request;
-    request.mutable_id()->CopyFrom(id_);
+    request.set_allocated_id(std::make_unique<Core::TaskID>(id_).release());
     Core::Label label;
     label.set_str("label");
-    request.mutable_label()->CopyFrom(label);
+    request.set_allocated_label(std::make_unique<Core::Label>(label).release());
 
     EXPECT_CALL(*stub, RemoveLabel(_, request, _))
             .WillOnce(testing::Invoke(

--- a/test/transfer/TaskManagerServiceTest.cpp
+++ b/test/transfer/TaskManagerServiceTest.cpp
@@ -249,7 +249,7 @@ TEST_F(TaskManagerGRPCServiceTest, shouldReturnSuccessOnIsPresent)
     request.CopyFrom(id_);
     Core::ModelRequestResult result;
 
-    grpc::Status status = service_->IsPresent(&context, &request, &result);
+    grpc::Status status = service_->CheckTask(&context, &request, &result);
     ASSERT_TRUE(status.ok());
     ASSERT_TRUE(result.has_id());
     EXPECT_EQ(id_, result.id());
@@ -261,7 +261,7 @@ TEST_F(TaskManagerGRPCServiceTest, shouldReturnIDNotFoundOnIsPresent)
     Core::TaskID request;
     request.set_value(id_.value()+1);
     Core::ModelRequestResult result;
-    grpc::Status status = service_->IsPresent(&context, &request, &result);
+    grpc::Status status = service_->CheckTask(&context, &request, &result);
     ASSERT_TRUE(status.ok());
     ASSERT_TRUE(result.has_status());
     EXPECT_EQ(Core::ModelRequestResult_Status_ID_NOT_FOUND, result.status());

--- a/test/transfer/TaskManagerServiceTest.cpp
+++ b/test/transfer/TaskManagerServiceTest.cpp
@@ -97,8 +97,8 @@ TEST_F(TaskManagerGRPCServiceTest, shouldAddSubtask)
 {
     grpc::ServerContext context;
     Core::TaskEntity request;
-    request.mutable_data()->CopyFrom(task_);
-    request.mutable_id()->CopyFrom(id_);
+    request.set_allocated_id(std::make_unique<Core::TaskID>(id_).release());
+    request.set_allocated_data(std::make_unique<Core::Task>(task_).release());
     Core::ModelRequestResult result;
     grpc::Status status = service_->AddSubtask(&context, &request, &result);
     ASSERT_TRUE(status.ok());
@@ -115,10 +115,12 @@ TEST_F(TaskManagerGRPCServiceTest, shouldEditTask)
 {
     grpc::ServerContext context;
     Core::TaskEntity request;
-    request.mutable_data()->CopyFrom(task_);
+
+    request.set_allocated_id(std::make_unique<Core::TaskID>(id_).release());
     std::string new_title = "edited";
-    request.mutable_data()->set_title(new_title);
-    request.mutable_id()->CopyFrom(id_);
+    auto task = std::make_unique<Core::Task>(task_);
+    task->set_title(new_title);
+    request.set_allocated_data(task.release());
     Core::ModelRequestResult result;
     grpc::Status status = service_->Edit(&context, &request, &result);
     ASSERT_TRUE(status.ok());
@@ -133,10 +135,13 @@ TEST_F(TaskManagerGRPCServiceTest, shouldFailToEditTaskWithWrongID)
 {
     grpc::ServerContext context;
     Core::TaskEntity request;
-    request.mutable_data()->CopyFrom(task_);
+    auto id = std::make_unique<Core::TaskID>(id_);
+    id->set_value(id->value()+1);
+    request.set_allocated_id(id.release());
     std::string new_title = "edited";
-    request.mutable_data()->set_title(new_title);
-    request.mutable_id()->set_value(id_.value()+1);
+    auto task = std::make_unique<Core::Task>(task_);
+    task->set_title(new_title);
+    request.set_allocated_data(task.release());
     Core::ModelRequestResult result;
     grpc::Status status = service_->Edit(&context, &request, &result);
     ASSERT_TRUE(status.ok());
@@ -213,8 +218,8 @@ TEST_F(TaskManagerGRPCServiceTest, shouldDeleteTaskWithSubtasks)
 {
     grpc::ServerContext context;
     Core::TaskEntity request1;
-    request1.mutable_id()->CopyFrom(id_);
-    request1.mutable_data()->CopyFrom(task_);
+    request1.set_allocated_id(std::make_unique<Core::TaskID>(id_).release());
+    request1.set_allocated_data(std::make_unique<Core::Task>(task_).release());
     Core::ModelRequestResult result;
     service_->AddSubtask(&context, &request1, &result);
 
@@ -271,9 +276,11 @@ TEST_F(TaskManagerGRPCServiceTest, shouldAddLabel)
 {
     grpc::ServerContext context;
     Transfer::IDWithLabel request;
-    request.mutable_id()->CopyFrom(id_);
-    std::string new_label = "new_label";
-    request.mutable_label()->set_str(new_label);
+    request.set_allocated_id(std::make_unique<Core::TaskID>(id_).release());
+    std::string new_label_str = "new_label";
+    Core::Label new_label;
+    new_label.set_str(new_label_str);
+    request.set_allocated_label(std::make_unique<Core::Label>(new_label).release());
     Core::ModelRequestResult result;
 
     grpc::Status status = service_->AddLabel(&context, &request, &result);
@@ -286,16 +293,20 @@ TEST_F(TaskManagerGRPCServiceTest, shouldAddLabel)
     auto labels = tasks[0].data().labels();
     ASSERT_EQ(2, labels.size());
     EXPECT_EQ(task_.labels(0), labels[0]);
-    EXPECT_EQ(new_label, labels[1].str());
+    EXPECT_EQ(new_label, labels[1]);
 }
 
 TEST_F(TaskManagerGRPCServiceTest, shouldFailToAddLabelWithInvalidID)
 {
     grpc::ServerContext context;
     Transfer::IDWithLabel request;
-    request.mutable_id()->set_value(id_.value()+1);
-    std::string new_label = "new_label";
-    request.mutable_label()->set_str(new_label);
+    auto id = std::make_unique<Core::TaskID>(id_);
+    id->set_value(id->value()+1);
+    request.set_allocated_id(id.release());
+    std::string new_label_str = "new_label";
+    Core::Label new_label;
+    new_label.set_str(new_label_str);
+    request.set_allocated_label(std::make_unique<Core::Label>(new_label).release());
     Core::ModelRequestResult result;
 
     grpc::Status status = service_->AddLabel(&context, &request, &result);
@@ -314,9 +325,9 @@ TEST_F(TaskManagerGRPCServiceTest, shouldRemoveLabel)
 {
     grpc::ServerContext context;
     Transfer::IDWithLabel request;
-    request.mutable_id()->CopyFrom(id_);
+    request.set_allocated_id(std::make_unique<Core::TaskID>(id_).release());
     auto label_to_remove = task_.labels(0);
-    request.mutable_label()->CopyFrom(label_to_remove);
+    request.set_allocated_label(std::make_unique<Core::Label>(label_to_remove).release());
     Core::ModelRequestResult result;
 
     grpc::Status status = service_->RemoveLabel(&context, &request, &result);
@@ -334,9 +345,11 @@ TEST_F(TaskManagerGRPCServiceTest, shouldFailToRemoveLabelWithInvalidID)
 {
     grpc::ServerContext context;
     Transfer::IDWithLabel request;
-    request.mutable_id()->set_value(id_.value()+1);
+    auto id = std::make_unique<Core::TaskID>(id_);
+    id->set_value(id->value()+1);
+    request.set_allocated_id(id.release());
     auto label_to_remove = task_.labels(0);
-    request.mutable_label()->CopyFrom(label_to_remove);
+    request.set_allocated_label(std::make_unique<Core::Label>(label_to_remove).release());
     Core::ModelRequestResult result;
 
     grpc::Status status = service_->RemoveLabel(&context, &request, &result);
@@ -355,9 +368,10 @@ TEST_F(TaskManagerGRPCServiceTest, shouldFailToRemoveLabelWrongLabel)
 {
     grpc::ServerContext context;
     Transfer::IDWithLabel request;
-    request.mutable_id()->CopyFrom(id_);
-    std::string label_to_remove = "missing";
-    request.mutable_label()->set_str(label_to_remove);
+    request.set_allocated_id(std::make_unique<Core::TaskID>(id_).release());
+    Core::Label label_to_remove;
+    label_to_remove.set_str("missing");
+    request.set_allocated_label(std::make_unique<Core::Label>(label_to_remove).release());
     Core::ModelRequestResult result;
 
     grpc::Status status = service_->RemoveLabel(&context, &request, &result);
@@ -376,9 +390,10 @@ TEST_F(TaskManagerGRPCServiceTest, shouldRemoveAllLabels)
 {
     grpc::ServerContext context;
     Transfer::IDWithLabel request1;
-    request1.mutable_id()->CopyFrom(id_);
-    std::string new_label = "new_label";
-    request1.mutable_label()->set_str(new_label);
+    request1.set_allocated_id(std::make_unique<Core::TaskID>(id_).release());
+    Core::Label new_label;
+    new_label.set_str("new_label");
+    request1.set_allocated_label(std::make_unique<Core::Label>(new_label).release());
     Core::ModelRequestResult result;
 
     service_->AddLabel(&context, &request1, &result);
@@ -402,9 +417,10 @@ TEST_F(TaskManagerGRPCServiceTest, shouldFailToRemoveAllLabelsWithWrongID)
 {
     grpc::ServerContext context;
     Transfer::IDWithLabel request1;
-    request1.mutable_id()->CopyFrom(id_);
-    std::string new_label = "new_label";
-    request1.mutable_label()->set_str(new_label);
+    request1.set_allocated_id(std::make_unique<Core::TaskID>(id_).release());
+    Core::Label new_label;
+    new_label.set_str("new_label");
+    request1.set_allocated_label(std::make_unique<Core::Label>(new_label).release());
     Core::ModelRequestResult result;
 
     service_->AddLabel(&context, &request1, &result);
@@ -427,10 +443,11 @@ TEST_F(TaskManagerGRPCServiceTest, shouldFailToRemoveAllLabelsWithWrongID)
 TEST_F(TaskManagerGRPCServiceTest, shouldReplaceAllTasks)
 {
     Core::TaskEntity te;
-    te.mutable_data()->CopyFrom(task_);
-    std::string new_title = "new";
-    te.mutable_data()->set_title(new_title);
-    te.mutable_id()->CopyFrom(id_);
+    auto task = std::make_unique<Core::Task>(task_);
+    std::string new_title{"new"};
+    task->set_title(new_title);
+    te.set_allocated_data(task.release());
+    te.set_allocated_id(std::make_unique<Core::TaskID>(id_).release());
 
     Transfer::ManyTaskEntities request;
     request.mutable_tasks()->Add(std::move(te));

--- a/test/ui/ActionTest.cpp
+++ b/test/ui/ActionTest.cpp
@@ -58,7 +58,7 @@ public:
 TEST_F(ActionTest, shouldAddTask)
 {
     ASSERT_EQ(1, tm_->getTasks().size());
-    EXPECT_TRUE(ToBool(tm_->IsPresent(id_)));
+    EXPECT_TRUE(ToBool(tm_->CheckTask(id_)));
 }
 
 TEST_F(ActionTest, shouldAddSubtask)
@@ -70,7 +70,7 @@ TEST_F(ActionTest, shouldAddSubtask)
     ActionResult result_subtask = subact.execute(tm_);
     ASSERT_EQ(2, tm_->getTasks().size());
     ASSERT_TRUE(result_subtask.model_result);
-    auto check = tm_->IsPresent(result_subtask.model_result->id());
+    auto check = tm_->CheckTask(result_subtask.model_result->id());
     ASSERT_TRUE(check.has_id());
     EXPECT_NE(id_, result_subtask.model_result->id());
 
@@ -134,7 +134,7 @@ TEST_F(ActionTest, shouldEditTask)
     ActionResult result_edit = act.execute(tm_);
 
     ASSERT_EQ(1, tm_->getTasks().size());
-    EXPECT_TRUE(ToBool(tm_->IsPresent(id_)));
+    EXPECT_TRUE(ToBool(tm_->CheckTask(id_)));
 
     ASSERT_TRUE(result_edit.model_result);
     ASSERT_TRUE(result_edit.model_result->has_id());

--- a/test/ui/ActionTest.cpp
+++ b/test/ui/ActionTest.cpp
@@ -43,11 +43,11 @@ public:
 
     void SetUp() override {
         tm_ = std::shared_ptr<ModelInterface>(new TaskManager);
-        task_.set_title("test");
-        task_.set_priority(Core::Task::Priority::Task_Priority_HIGH);
-        task_.set_due_date(time(nullptr));
-        task_.add_labels("label");
-        task_.set_is_complete(false);
+        task_ = Core::createTask("test",
+                                 Core::Task::Priority::Task_Priority_HIGH,
+                                 time(nullptr),
+                                 "label",
+                                 false);
         AddTaskAction act{task_};
         ActionResult result = act.execute(tm_);
         id_ = result.model_result->id();
@@ -157,7 +157,9 @@ TEST_F(ActionTest, shouldGetTasksToShowWithNoArg)
 
 TEST_F(ActionTest, shouldGetTasksToShowWithLabelArg)
 {
-    GetTasksToShowByLabelAction act{"label"};
+    Core::Label label;
+    label.set_str("label");
+    GetTasksToShowByLabelAction act{label};
     ActionResult result = act.execute(tm_);
 
     ASSERT_TRUE(result.tasks);
@@ -263,14 +265,15 @@ TEST_F(ActionTest, shouldDeleteTaskValidIDWithSubtasks)
 
 TEST_F(ActionTest, shouldLabelTask)
 {
-    std::string label = "custom";
+    Core::Label label;
+    label.set_str("custom");
     LabelTaskAction act{id_, label};
     ActionResult result_label = act.execute(tm_);
     ASSERT_EQ(1, tm_->getTasks().size());
     ASSERT_TRUE(result_label.model_result);
     ASSERT_TRUE(result_label.model_result->has_id());
     EXPECT_EQ(result_label.model_result->id(), id_);
-    EXPECT_EQ("label", tm_->getTasks()[0].data().labels()[0]);
+    EXPECT_EQ("label", tm_->getTasks()[0].data().labels()[0].str());
     EXPECT_EQ(label, tm_->getTasks()[0].data().labels()[1]);
 }
 
@@ -278,14 +281,15 @@ TEST_F(ActionTest, shouldNotLabelTaskWithInvalidID)
 {
     Core::TaskID new_id;
     new_id.set_value(id_.value()+1);
-    std::string label = "custom";
+    Core::Label label;
+    label.set_str("custom");
     LabelTaskAction act{new_id, label};
     ActionResult result_label = act.execute(tm_);
     ASSERT_EQ(1, tm_->getTasks().size());
     ASSERT_TRUE(result_label.model_result);
     ASSERT_TRUE(result_label.model_result->has_status());
     EXPECT_EQ(result_label.model_result->status(), Core::ModelRequestResult_Status_ID_NOT_FOUND);
-    EXPECT_EQ("label", tm_->getTasks()[0].data().labels()[0]);
+    EXPECT_EQ("label", tm_->getTasks()[0].data().labels()[0].str());
 }
 
 TEST_F(ActionTest, shouldDoNothing)
@@ -301,8 +305,11 @@ TEST_F(ActionTest, shouldDoNothing)
 
 TEST_F(ActionTest, shouldClearAllLabelsOfTask)
 {
-    LabelTaskAction label_action(id_, "mylabel");
-    LabelTaskAction label_action2(id_, "mylabel2");
+    Core::Label mylabel, mylabel2;
+    mylabel.set_str("mylabel");
+    mylabel2.set_str("mylabel2");
+    LabelTaskAction label_action(id_, mylabel);
+    LabelTaskAction label_action2(id_, mylabel2);
     label_action.execute(tm_);
     label_action2.execute(tm_);
 
@@ -318,12 +325,15 @@ TEST_F(ActionTest, shouldClearAllLabelsOfTask)
 
 TEST_F(ActionTest, shouldClearOneLabelOfTask)
 {
-    LabelTaskAction label_action(id_, "mylabel");
-    LabelTaskAction label_action2(id_, "mylabel2");
+    Core::Label mylabel, mylabel2;
+    mylabel.set_str("mylabel");
+    mylabel2.set_str("mylabel2");
+    LabelTaskAction label_action(id_, mylabel);
+    LabelTaskAction label_action2(id_, mylabel2);
     label_action.execute(tm_);
     label_action2.execute(tm_);
 
-    ClearLabelOfTaskAction act{id_, "mylabel2"};
+    ClearLabelOfTaskAction act{id_, mylabel2};
     ActionResult result = act.execute(tm_);
     ASSERT_EQ(1, tm_->getTasks().size());
     ASSERT_TRUE(result.model_result);
@@ -332,7 +342,7 @@ TEST_F(ActionTest, shouldClearOneLabelOfTask)
 
     auto tasks = tm_->getTaskWithSubtasks(id_);
     EXPECT_EQ(2, tasks[0].data().labels().size());
-    EXPECT_EQ("mylabel", tasks[0].data().labels()[1]);
+    EXPECT_EQ(mylabel, tasks[0].data().labels()[1]);
 }
 
 TEST_F(ActionTest, shouldGetTaskToShowItsLabels)

--- a/test/ui/ContextTest.cpp
+++ b/test/ui/ContextTest.cpp
@@ -9,7 +9,16 @@
 
 class ContextTest : public ::testing::Test
 {
+public:
+    Core::Task task_;
 
+    void SetUp() override {
+        task_ = Core::createTask("test",
+                                 Core::Task::Priority::Task_Priority_NONE,
+                                 time(nullptr),
+                                 "label",
+                                 false);
+    }
 };
 
 TEST_F(ContextTest, shouldSetID)
@@ -24,13 +33,7 @@ TEST_F(ContextTest, shouldSetID)
 TEST_F(ContextTest, shouldSetTasks)
 {
     TaskManager tm;
-    Core::Task t;
-    t.set_title("test");
-    t.set_priority(Core::Task_Priority_NONE);
-    t.add_labels("label");
-    t.set_due_date(time(nullptr));
-    t.set_is_complete(false);
-    tm.Add(t);
+    tm.Add(task_);
     Context c;
     auto tasks = tm.getTasks();
     c.setTasks(tasks);
@@ -41,19 +44,13 @@ TEST_F(ContextTest, shouldSetTasks)
 }
 
 TEST_F(ContextTest, shouldSetData){
-    Core::Task t;
-    t.set_title("test");
-    t.set_priority(Core::Task_Priority_NONE);
-    t.add_labels("label");
-    t.set_due_date(time(nullptr));
-    t.set_is_complete(false);
     Context c;
-    c.setTask(t);
-    EXPECT_EQ(t.title(), c.task().title());
-    EXPECT_EQ(t.priority(), c.task().priority());
-    EXPECT_EQ(t.due_date(), c.task().due_date());
-    EXPECT_EQ(t.labels()[0], c.task().labels()[0]);
-    EXPECT_EQ(t.is_complete(), c.task().is_complete());
+    c.setTask(task_);
+    EXPECT_EQ(task_.title(), c.task().title());
+    EXPECT_EQ(task_.priority(), c.task().priority());
+    EXPECT_EQ(task_.due_date(), c.task().due_date());
+    EXPECT_EQ(task_.labels()[0], c.task().labels()[0]);
+    EXPECT_EQ(task_.is_complete(), c.task().is_complete());
 }
 
 TEST_F(ContextTest, shouldSetTitle){

--- a/test/ui/IntegrationTest.cpp
+++ b/test/ui/IntegrationTest.cpp
@@ -95,17 +95,17 @@ TEST_F(IntegrationTest, shouldCreateThreeTasksCompleteOneDeleteOne)
 
     Core::TaskID id;
     id.set_value(1);
-    ASSERT_TRUE(ToBool(tm->IsPresent(id)));
+    ASSERT_TRUE(ToBool(tm->CheckTask(id)));
     EXPECT_EQ(tm->getTasks()[0].id(), id);
     EXPECT_TRUE(tm->getTasks()[0].data().is_complete());
 
     id.set_value(2);
-    ASSERT_TRUE(ToBool(tm->IsPresent(id)));
+    ASSERT_TRUE(ToBool(tm->CheckTask(id)));
     EXPECT_EQ(tm->getTasks()[1].id(), id);
     EXPECT_FALSE(tm->getTasks()[1].data().is_complete());
 
     id.set_value(3);
-    EXPECT_FALSE(ToBool(tm->IsPresent(id)));
+    EXPECT_FALSE(ToBool(tm->CheckTask(id)));
 
     EXPECT_EQ(4, tm->gen()->state());
 }
@@ -144,19 +144,19 @@ TEST_F(IntegrationTest, shouldCreateTaskWithSubtasksCompleteAll)
     // check completeness
     Core::TaskID id;
     id.set_value(1);
-    ASSERT_TRUE(ToBool(tm->IsPresent(id)));
+    ASSERT_TRUE(ToBool(tm->CheckTask(id)));
     EXPECT_EQ(tm->getTasks()[0].id(), id);
     EXPECT_TRUE(tm->getTasks()[0].data().is_complete());
 
     Core::TaskID id2;
     id2.set_value(2);
-    ASSERT_TRUE(ToBool(tm->IsPresent(id2)));
+    ASSERT_TRUE(ToBool(tm->CheckTask(id2)));
     EXPECT_EQ(tm->getTasks()[1].id(), id2);
     EXPECT_TRUE(tm->getTasks()[1].data().is_complete());
 
     Core::TaskID id3;
     id3.set_value(3);
-    ASSERT_TRUE(ToBool(tm->IsPresent(id3)));
+    ASSERT_TRUE(ToBool(tm->CheckTask(id3)));
     EXPECT_EQ(tm->getTasks()[2].id(), id3);
     EXPECT_TRUE(tm->getTasks()[2].data().is_complete());
 
@@ -207,18 +207,18 @@ TEST_F(IntegrationTest, shouldCreateTaskWithSubtasksLabelTwo)
     // check labels
     Core::TaskID id;
     id.set_value(1);
-    ASSERT_TRUE(ToBool(tm->IsPresent(id)));
+    ASSERT_TRUE(ToBool(tm->CheckTask(id)));
     EXPECT_TRUE(tasks[0].data().labels().empty());
 
     Core::TaskID id2;
     id2.set_value(2);
-    ASSERT_TRUE(ToBool(tm->IsPresent(id2)));
+    ASSERT_TRUE(ToBool(tm->CheckTask(id2)));
     EXPECT_EQ(1, tasks[1].data().labels().size());
     EXPECT_EQ("l2", tasks[1].data().labels()[0].str());
 
     Core::TaskID id3;
     id3.set_value(3);
-    ASSERT_TRUE(ToBool(tm->IsPresent(id3)));
+    ASSERT_TRUE(ToBool(tm->CheckTask(id3)));
     EXPECT_EQ(1, tasks[2].data().labels().size());
     EXPECT_EQ("l3", tasks[2].data().labels()[0].str());
 
@@ -263,11 +263,11 @@ TEST_F(IntegrationTest, shouldCreateThreeTasksDeleteTwoWithConfirm)
 
     Core::TaskID id;
     id.set_value(1);
-    ASSERT_FALSE(ToBool(tm->IsPresent(id)));
+    ASSERT_FALSE(ToBool(tm->CheckTask(id)));
     id.set_value(2);
-    ASSERT_TRUE(ToBool(tm->IsPresent(id)));
+    ASSERT_TRUE(ToBool(tm->CheckTask(id)));
     id.set_value(3);
-    ASSERT_FALSE(ToBool(tm->IsPresent(id)));
+    ASSERT_FALSE(ToBool(tm->CheckTask(id)));
 
     for (int i = 0; i <  prompts.size(); ++i) {
         EXPECT_EQ(prompts[i], prompts_expected[i]);
@@ -315,7 +315,7 @@ TEST_F(IntegrationTest, shouldCreateTaskWithBadInputs)
 
     Core::TaskID id;
     id.set_value(1);
-    EXPECT_TRUE(ToBool(tm->IsPresent(id)));
+    EXPECT_TRUE(ToBool(tm->CheckTask(id)));
 
     for (int i = 0; i <  prompts.size(); ++i) {
         EXPECT_EQ(prompts[i], prompts_expected[i]);
@@ -396,17 +396,17 @@ TEST_F(IntegrationTest, shouldCreateThreeTasksInAHeirarcySaveAndLoad)
     id2.set_value(2);
     id3.set_value(3);
 
-    ASSERT_TRUE(ToBool(tm->IsPresent(id1)));
+    ASSERT_TRUE(ToBool(tm->CheckTask(id1)));
     EXPECT_TRUE(tm->getTasks()[0].data().is_complete());
     EXPECT_EQ(tm->getTasks()[0].data().title(), "Task 1");
     EXPECT_FALSE(tm->getTasks()[0].has_parent());
 
-    ASSERT_TRUE(ToBool(tm->IsPresent(id2)));
+    ASSERT_TRUE(ToBool(tm->CheckTask(id2)));
     EXPECT_TRUE(tm->getTasks()[1].data().is_complete());
     EXPECT_EQ(tm->getTasks()[1].data().title(), "Subtask 2");
     EXPECT_EQ(id1, tm->getTasks()[1].parent());
 
-    ASSERT_TRUE(ToBool(tm->IsPresent(id3)));
+    ASSERT_TRUE(ToBool(tm->CheckTask(id3)));
     EXPECT_TRUE(tm->getTasks()[2].data().is_complete());
     EXPECT_EQ(tm->getTasks()[2].data().title(), "Subtask 3");
     EXPECT_EQ(id2, tm->getTasks()[2].parent());

--- a/test/ui/IntegrationTest.cpp
+++ b/test/ui/IntegrationTest.cpp
@@ -214,13 +214,13 @@ TEST_F(IntegrationTest, shouldCreateTaskWithSubtasksLabelTwo)
     id2.set_value(2);
     ASSERT_TRUE(ToBool(tm->IsPresent(id2)));
     EXPECT_EQ(1, tasks[1].data().labels().size());
-    EXPECT_EQ("l2", tasks[1].data().labels()[0]);
+    EXPECT_EQ("l2", tasks[1].data().labels()[0].str());
 
     Core::TaskID id3;
     id3.set_value(3);
     ASSERT_TRUE(ToBool(tm->IsPresent(id3)));
     EXPECT_EQ(1, tasks[2].data().labels().size());
-    EXPECT_EQ("l3", tasks[2].data().labels()[0]);
+    EXPECT_EQ("l3", tasks[2].data().labels()[0].str());
 
     // check parents
     EXPECT_FALSE(tm->getTasks()[0].has_parent());


### PR DESCRIPTION
Tiny type, large changes. 
Task Manager API updated to use label as a Core::Label (which before was used only within the transport layer), instead of a generic std::string