### PR TITLE
Renamed IsPresent to CheckTask

### DIFF
--- a/proto/Service.proto
+++ b/proto/Service.proto
@@ -15,7 +15,7 @@ service TaskManager {
   rpc Complete (Core.TaskID) returns (Core.ModelRequestResult) {}
   rpc Uncomplete (Core.TaskID) returns (Core.ModelRequestResult) {}
   rpc Delete (Core.TaskID) returns (Core.ModelRequestResult) {}
-  rpc IsPresent (Core.TaskID) returns (Core.ModelRequestResult) {}
+  rpc CheckTask (Core.TaskID) returns (Core.ModelRequestResult) {}
   rpc AddLabel (IDWithLabel) returns (Core.ModelRequestResult) {}
   rpc RemoveLabel (IDWithLabel) returns (Core.ModelRequestResult) {}
   rpc RemoveAllLabels (Core.TaskID) returns (Core.ModelRequestResult) {}

--- a/src/model/ModelInterface.h
+++ b/src/model/ModelInterface.h
@@ -28,7 +28,7 @@ public:
     virtual Core::ModelRequestResult Complete(const Core::TaskID &) = 0;
     virtual Core::ModelRequestResult Uncomplete(const Core::TaskID &) = 0;
     virtual Core::ModelRequestResult Delete(const Core::TaskID &, bool deleteChildren) = 0;
-    virtual Core::ModelRequestResult IsPresent(const Core::TaskID &) const = 0;
+    virtual Core::ModelRequestResult CheckTask(const Core::TaskID &) const = 0;
     virtual Core::ModelRequestResult AddLabel(const Core::TaskID &, const Core::Label &label) = 0;
     virtual Core::ModelRequestResult RemoveLabel(const Core::TaskID &, const Core::Label &label) = 0;
     virtual Core::ModelRequestResult RemoveAllLabels(const Core::TaskID &) = 0;

--- a/src/model/TaskManager.cpp
+++ b/src/model/TaskManager.cpp
@@ -137,7 +137,7 @@ std::vector<Core::TaskEntity> TaskManager::getTaskWithSubtasks(const Core::TaskI
         for (const auto &ch_id: ChildrenOf(id)) {
             auto ch_tasks = getTaskWithSubtasks(ch_id);
             for (auto &ch_task: ch_tasks) {
-                ch_task.mutable_parent()->CopyFrom(*ParentOf(ch_task.id()));
+                ch_task.set_allocated_parent(std::make_unique<Core::TaskID>(*ParentOf(ch_task.id())).release());
             }
             tasks.insert(tasks.end(), ch_tasks.begin(), ch_tasks.end());
         }

--- a/src/model/TaskManager.h
+++ b/src/model/TaskManager.h
@@ -36,7 +36,7 @@ public:
     Core::ModelRequestResult Complete(const Core::TaskID &) override;
     Core::ModelRequestResult Uncomplete(const Core::TaskID &) override;
     Core::ModelRequestResult Delete(const Core::TaskID &id, bool deleteChildren) override;
-    Core::ModelRequestResult IsPresent(const Core::TaskID &id) const override;
+    Core::ModelRequestResult CheckTask(const Core::TaskID &id) const override;
     Core::ModelRequestResult AddLabel(const Core::TaskID &, const Core::Label &) override;
     Core::ModelRequestResult RemoveLabel(const Core::TaskID &, const Core::Label &) override;
     Core::ModelRequestResult RemoveAllLabels(const Core::TaskID &) override;

--- a/src/transport/TaskManagerGRPCClient.cpp
+++ b/src/transport/TaskManagerGRPCClient.cpp
@@ -51,8 +51,8 @@ Core::ModelRequestResult TaskManagerGRPCClient::Add(const Core::Task& request) {
 
 Core::ModelRequestResult TaskManagerGRPCClient::AddSubtask(const Core::Task& task, const Core::TaskID &id) {
     Core::TaskEntity request;
-    request.mutable_id()->CopyFrom(id);
-    request.mutable_data()->CopyFrom(task);
+    request.set_allocated_id(std::make_unique<Core::TaskID>(id).release());
+    request.set_allocated_data(std::make_unique<Core::Task>(task).release());
     Core::ModelRequestResult reply;
     grpc::ClientContext context;
     grpc::Status status = stub_->AddSubtask(&context, request, &reply);
@@ -62,8 +62,8 @@ Core::ModelRequestResult TaskManagerGRPCClient::AddSubtask(const Core::Task& tas
 
 Core::ModelRequestResult TaskManagerGRPCClient::Edit(const Core::TaskID &id, const Core::Task& task) {
     Core::TaskEntity request;
-    request.mutable_id()->CopyFrom(id);
-    request.mutable_data()->CopyFrom(task);
+    request.set_allocated_id(std::make_unique<Core::TaskID>(id).release());
+    request.set_allocated_data(std::make_unique<Core::Task>(task).release());
     Core::ModelRequestResult reply;
     grpc::ClientContext context;
     grpc::Status status = stub_->Edit(&context, request, &reply);
@@ -105,8 +105,8 @@ Core::ModelRequestResult TaskManagerGRPCClient::CheckTask(const Core::TaskID &re
 
 Core::ModelRequestResult TaskManagerGRPCClient::AddLabel(const Core::TaskID &id, const Core::Label &label) {
     Transfer::IDWithLabel request;
-    request.mutable_id()->CopyFrom(id);
-    request.mutable_label()->CopyFrom(label);
+    request.set_allocated_id(std::make_unique<Core::TaskID>(id).release());
+    request.set_allocated_label(std::make_unique<Core::Label>(label).release());
     Core::ModelRequestResult reply;
     grpc::ClientContext context;
     grpc::Status status = stub_->AddLabel(&context, request, &reply);
@@ -116,8 +116,8 @@ Core::ModelRequestResult TaskManagerGRPCClient::AddLabel(const Core::TaskID &id,
 
 Core::ModelRequestResult TaskManagerGRPCClient::RemoveLabel(const Core::TaskID &id, const Core::Label &label) {
     Transfer::IDWithLabel request;
-    request.mutable_id()->CopyFrom(id);
-    request.mutable_label()->CopyFrom(label);
+    request.set_allocated_id(std::make_unique<Core::TaskID>(id).release());
+    request.set_allocated_label(std::make_unique<Core::Label>(label).release());
     Core::ModelRequestResult reply;
     grpc::ClientContext context;
     grpc::Status status = stub_->RemoveLabel(&context, request, &reply);

--- a/src/transport/TaskManagerGRPCClient.cpp
+++ b/src/transport/TaskManagerGRPCClient.cpp
@@ -95,10 +95,10 @@ Core::ModelRequestResult TaskManagerGRPCClient::Delete(const Core::TaskID &reque
     return reply;
 }
 
-Core::ModelRequestResult TaskManagerGRPCClient::IsPresent(const Core::TaskID &request) const {
+Core::ModelRequestResult TaskManagerGRPCClient::CheckTask(const Core::TaskID &request) const {
     Core::ModelRequestResult reply;
     grpc::ClientContext context;
-    grpc::Status status = stub_->IsPresent(&context, request, &reply);
+    grpc::Status status = stub_->CheckTask(&context, request, &reply);
 
     return reply;
 }

--- a/src/transport/TaskManagerGRPCClient.h
+++ b/src/transport/TaskManagerGRPCClient.h
@@ -27,7 +27,7 @@ public:
     Core::ModelRequestResult Complete(const Core::TaskID &) override;
     Core::ModelRequestResult Uncomplete(const Core::TaskID &) override;
     Core::ModelRequestResult Delete(const Core::TaskID &, bool deleteChildren) override;
-    Core::ModelRequestResult IsPresent(const Core::TaskID &) const override;
+    Core::ModelRequestResult CheckTask(const Core::TaskID &) const override;
     Core::ModelRequestResult AddLabel(const Core::TaskID &, const Core::Label &label) override;
     Core::ModelRequestResult RemoveLabel(const Core::TaskID &, const Core::Label &label) override;
     Core::ModelRequestResult RemoveAllLabels(const Core::TaskID &) override;

--- a/src/transport/TaskManagerGRPCService.cpp
+++ b/src/transport/TaskManagerGRPCService.cpp
@@ -76,10 +76,10 @@ grpc::Status TaskManagerGRPCService::Delete(grpc::ServerContext* context,
     return grpc::Status::OK;
 }
 
-grpc::Status TaskManagerGRPCService::IsPresent(grpc::ServerContext* context,
+grpc::Status TaskManagerGRPCService::CheckTask(grpc::ServerContext* context,
                                                const Core::TaskID* id,
                                                Core::ModelRequestResult* result) {
-    *result = model_->IsPresent(*id);
+    *result = model_->CheckTask(*id);
     return grpc::Status::OK;
 }
 

--- a/src/transport/TaskManagerGRPCService.h
+++ b/src/transport/TaskManagerGRPCService.h
@@ -32,8 +32,8 @@ public:
                      Core::ModelRequestResult* result) override;
     grpc::Status Delete(grpc::ServerContext* context, const Core::TaskID* id,
                      Core::ModelRequestResult* result) override;
-    grpc::Status IsPresent(grpc::ServerContext* context, const Core::TaskID* id,
-                     Core::ModelRequestResult* result) override;
+    grpc::Status CheckTask(grpc::ServerContext* context, const Core::TaskID* id,
+                           Core::ModelRequestResult* result) override;
     grpc::Status AddLabel(grpc::ServerContext* context, const Transfer::IDWithLabel* msg,
                      Core::ModelRequestResult* result) override;
     grpc::Status RemoveLabel(grpc::ServerContext* context, const Transfer::IDWithLabel* msg,

--- a/src/ui/actions/GetTaskToShowByIDAction.cpp
+++ b/src/ui/actions/GetTaskToShowByIDAction.cpp
@@ -9,7 +9,7 @@ GetTaskToShowByIDAction::GetTaskToShowByIDAction(const Core::TaskID &id) : id_{i
 }
 
 ActionResult GetTaskToShowByIDAction::execute(const std::shared_ptr<ModelInterface> &model) {
-    auto check = model->IsPresent(id_);
+    auto check = model->CheckTask(id_);
     if (!ToBool(check))
         return check;
 

--- a/src/ui/actions/GetTaskToShowLabelsAction.cpp
+++ b/src/ui/actions/GetTaskToShowLabelsAction.cpp
@@ -11,7 +11,7 @@ GetTaskToShowLabelsAction::GetTaskToShowLabelsAction(const std::optional<Core::T
 ActionResult GetTaskToShowLabelsAction::execute(const std::shared_ptr<ModelInterface> &model) {
     Core::ModelRequestResult result;
     if (id_) {
-        auto check = model->IsPresent(*id_);
+        auto check = model->CheckTask(*id_);
         if (!ToBool(check))
             return check;
     } else {

--- a/src/ui/actions/ValidateIDAction.cpp
+++ b/src/ui/actions/ValidateIDAction.cpp
@@ -11,7 +11,7 @@ ValidateIDAction::ValidateIDAction(const std::optional<Core::TaskID> &id) : id_{
 ActionResult ValidateIDAction::execute(const std::shared_ptr<ModelInterface> &model) {
     Core::ModelRequestResult result;
     if (id_) {
-        return model->IsPresent(*id_);
+        return model->CheckTask(*id_);
     } else {
         result.set_status(Core::ModelRequestResult_Status_TAKES_ID);
         return result;

--- a/src/utilities/TaskEntityUtils.cpp
+++ b/src/utilities/TaskEntityUtils.cpp
@@ -18,15 +18,15 @@ Core::TaskEntity  Core::createTaskEntity(const Core::TaskID &id,
                                         const Core::Task &task,
                                         const Core::TaskID &parent_id) {
     Core::TaskEntity te;
-    te.mutable_id()->CopyFrom(id);
-    te.mutable_data()->CopyFrom(task);
-    te.mutable_parent()->CopyFrom(parent_id);
+    te.set_allocated_id(std::make_unique<Core::TaskID>(id).release());
+    te.set_allocated_data(std::make_unique<Core::Task>(task).release());
+    te.set_allocated_parent(std::make_unique<Core::TaskID>(parent_id).release());
     return te;
 }
 Core::TaskEntity  Core::createTaskEntity(const Core::TaskID &id,
                                          const Core::Task &task) {
     Core::TaskEntity te;
-    te.mutable_id()->CopyFrom(id);
-    te.mutable_data()->CopyFrom(task);
+    te.set_allocated_id(std::make_unique<Core::TaskID>(id).release());
+    te.set_allocated_data(std::make_unique<Core::Task>(task).release());
     return te;
 }

--- a/test/model/DISABLED_TaskManagerStressTest.cpp
+++ b/test/model/DISABLED_TaskManagerStressTest.cpp
@@ -122,7 +122,7 @@ std::vector<Core::TaskEntity> runCommand(const Command &command, TaskManager &tm
             tm.Delete(getRandomID(tm), true);
             break;
         case Command::IS_PRESENT:
-            tm.IsPresent(id);
+            tm.CheckTask(id);
             break;
         case Command::LABEL:
             tm.AddLabel(getRandomID(tm), getRandomLabel());

--- a/test/model/TaskManagerTest.cpp
+++ b/test/model/TaskManagerTest.cpp
@@ -47,7 +47,7 @@ TEST_F(TaskManagerTest, shouldAddTask)
     ASSERT_TRUE(result.has_id());
     const Core::TaskID& id = result.id();
     ASSERT_EQ(1, tm.size());
-    EXPECT_TRUE(ToBool(tm.IsPresent(id)));
+    EXPECT_TRUE(ToBool(tm.CheckTask(id)));
 }
 
 TEST_F(TaskManagerTest, shouldFailToAddSubtaskWithMissingParent)
@@ -75,8 +75,8 @@ TEST_F(TaskManagerTest, shouldAddSubtask)
     const auto& id_ch = subtask_result.id();
 
     ASSERT_EQ(2, tm.size());
-    EXPECT_TRUE(ToBool(tm.IsPresent(id)));
-    EXPECT_TRUE(ToBool(tm.IsPresent(id_ch)));
+    EXPECT_TRUE(ToBool(tm.CheckTask(id)));
+    EXPECT_TRUE(ToBool(tm.CheckTask(id_ch)));
     EXPECT_EQ(id, tm.getTasks()[1].parent());
 }
 
@@ -113,7 +113,7 @@ TEST_F(TaskManagerTest, shouldDeleteTask)
     ASSERT_TRUE(result.has_id());
     const auto& id = result.id();
     tm.Delete(id, false);
-    EXPECT_FALSE(ToBool(tm.IsPresent(id)));
+    EXPECT_FALSE(ToBool(tm.CheckTask(id)));
 }
 
 TEST_F(TaskManagerTest, shouldFailToDeleteTaskWithWrongID)

--- a/test/transfer/TaskManagerClinetTest.cpp
+++ b/test/transfer/TaskManagerClinetTest.cpp
@@ -227,7 +227,7 @@ TEST_F(TaskManagerGRPCClientTest, shouldSendIsPresentRequest)
 {
     auto stub = std::make_unique<MockTaskManagerStub>();
 
-    EXPECT_CALL(*stub, IsPresent(_, id_, _))
+    EXPECT_CALL(*stub, CheckTask(_, id_, _))
             .WillOnce(testing::Invoke(
                     [this] (ClientContext*, const TaskID &request, Core::ModelRequestResult* reply) -> grpc::Status {
                         reply->set_allocated_id(std::make_unique<Core::TaskID>(id_).release());
@@ -235,7 +235,7 @@ TEST_F(TaskManagerGRPCClientTest, shouldSendIsPresentRequest)
                     }));
 
     TaskManagerGRPCClient client{std::move(stub)};
-    Core::ModelRequestResult result = client.IsPresent(id_);
+    Core::ModelRequestResult result = client.CheckTask(id_);
     ASSERT_TRUE(result.has_id());
     EXPECT_EQ(result.id(), id_);
 }

--- a/test/transfer/TaskManagerClinetTest.cpp
+++ b/test/transfer/TaskManagerClinetTest.cpp
@@ -41,8 +41,8 @@ public:
                                  false);
         task_.set_is_complete(false);
         id_.set_value(42);
-        entity_.mutable_id()->CopyFrom(id_);
-        entity_.mutable_data()->CopyFrom(task_);
+        entity_.set_allocated_id(std::make_unique<Core::TaskID>(id_).release());
+        entity_.set_allocated_data(std::make_unique<Core::Task>(task_).release());
     }
 };
 
@@ -244,10 +244,10 @@ TEST_F(TaskManagerGRPCClientTest, shouldSendAddLabelRequest)
 {
     auto stub = std::make_unique<MockTaskManagerStub>();
     IDWithLabel request;
-    request.mutable_id()->CopyFrom(id_);
+    request.set_allocated_id(std::make_unique<Core::TaskID>(id_).release());
     Core::Label new_label;
     new_label.set_str("new_label");
-    request.mutable_label()->CopyFrom(new_label);
+    request.set_allocated_label(std::make_unique<Core::Label>(new_label).release());
 
     EXPECT_CALL(*stub, AddLabel(_, request, _))
             .WillOnce(testing::Invoke(
@@ -266,10 +266,10 @@ TEST_F(TaskManagerGRPCClientTest, shouldSendRemoveLabelRequest)
 {
     auto stub = std::make_unique<MockTaskManagerStub>();
     IDWithLabel request;
-    request.mutable_id()->CopyFrom(id_);
+    request.set_allocated_id(std::make_unique<Core::TaskID>(id_).release());
     Core::Label label;
     label.set_str("label");
-    request.mutable_label()->CopyFrom(label);
+    request.set_allocated_label(std::make_unique<Core::Label>(label).release());
 
     EXPECT_CALL(*stub, RemoveLabel(_, request, _))
             .WillOnce(testing::Invoke(

--- a/test/transfer/TaskManagerServiceTest.cpp
+++ b/test/transfer/TaskManagerServiceTest.cpp
@@ -249,7 +249,7 @@ TEST_F(TaskManagerGRPCServiceTest, shouldReturnSuccessOnIsPresent)
     request.CopyFrom(id_);
     Core::ModelRequestResult result;
 
-    grpc::Status status = service_->IsPresent(&context, &request, &result);
+    grpc::Status status = service_->CheckTask(&context, &request, &result);
     ASSERT_TRUE(status.ok());
     ASSERT_TRUE(result.has_id());
     EXPECT_EQ(id_, result.id());
@@ -261,7 +261,7 @@ TEST_F(TaskManagerGRPCServiceTest, shouldReturnIDNotFoundOnIsPresent)
     Core::TaskID request;
     request.set_value(id_.value()+1);
     Core::ModelRequestResult result;
-    grpc::Status status = service_->IsPresent(&context, &request, &result);
+    grpc::Status status = service_->CheckTask(&context, &request, &result);
     ASSERT_TRUE(status.ok());
     ASSERT_TRUE(result.has_status());
     EXPECT_EQ(Core::ModelRequestResult_Status_ID_NOT_FOUND, result.status());

--- a/test/transfer/TaskManagerServiceTest.cpp
+++ b/test/transfer/TaskManagerServiceTest.cpp
@@ -97,8 +97,8 @@ TEST_F(TaskManagerGRPCServiceTest, shouldAddSubtask)
 {
     grpc::ServerContext context;
     Core::TaskEntity request;
-    request.mutable_data()->CopyFrom(task_);
-    request.mutable_id()->CopyFrom(id_);
+    request.set_allocated_id(std::make_unique<Core::TaskID>(id_).release());
+    request.set_allocated_data(std::make_unique<Core::Task>(task_).release());
     Core::ModelRequestResult result;
     grpc::Status status = service_->AddSubtask(&context, &request, &result);
     ASSERT_TRUE(status.ok());
@@ -115,10 +115,12 @@ TEST_F(TaskManagerGRPCServiceTest, shouldEditTask)
 {
     grpc::ServerContext context;
     Core::TaskEntity request;
-    request.mutable_data()->CopyFrom(task_);
+
+    request.set_allocated_id(std::make_unique<Core::TaskID>(id_).release());
     std::string new_title = "edited";
-    request.mutable_data()->set_title(new_title);
-    request.mutable_id()->CopyFrom(id_);
+    auto task = std::make_unique<Core::Task>(task_);
+    task->set_title(new_title);
+    request.set_allocated_data(task.release());
     Core::ModelRequestResult result;
     grpc::Status status = service_->Edit(&context, &request, &result);
     ASSERT_TRUE(status.ok());
@@ -133,10 +135,13 @@ TEST_F(TaskManagerGRPCServiceTest, shouldFailToEditTaskWithWrongID)
 {
     grpc::ServerContext context;
     Core::TaskEntity request;
-    request.mutable_data()->CopyFrom(task_);
+    auto id = std::make_unique<Core::TaskID>(id_);
+    id->set_value(id->value()+1);
+    request.set_allocated_id(id.release());
     std::string new_title = "edited";
-    request.mutable_data()->set_title(new_title);
-    request.mutable_id()->set_value(id_.value()+1);
+    auto task = std::make_unique<Core::Task>(task_);
+    task->set_title(new_title);
+    request.set_allocated_data(task.release());
     Core::ModelRequestResult result;
     grpc::Status status = service_->Edit(&context, &request, &result);
     ASSERT_TRUE(status.ok());
@@ -213,8 +218,8 @@ TEST_F(TaskManagerGRPCServiceTest, shouldDeleteTaskWithSubtasks)
 {
     grpc::ServerContext context;
     Core::TaskEntity request1;
-    request1.mutable_id()->CopyFrom(id_);
-    request1.mutable_data()->CopyFrom(task_);
+    request1.set_allocated_id(std::make_unique<Core::TaskID>(id_).release());
+    request1.set_allocated_data(std::make_unique<Core::Task>(task_).release());
     Core::ModelRequestResult result;
     service_->AddSubtask(&context, &request1, &result);
 
@@ -271,9 +276,11 @@ TEST_F(TaskManagerGRPCServiceTest, shouldAddLabel)
 {
     grpc::ServerContext context;
     Transfer::IDWithLabel request;
-    request.mutable_id()->CopyFrom(id_);
-    std::string new_label = "new_label";
-    request.mutable_label()->set_str(new_label);
+    request.set_allocated_id(std::make_unique<Core::TaskID>(id_).release());
+    std::string new_label_str = "new_label";
+    Core::Label new_label;
+    new_label.set_str(new_label_str);
+    request.set_allocated_label(std::make_unique<Core::Label>(new_label).release());
     Core::ModelRequestResult result;
 
     grpc::Status status = service_->AddLabel(&context, &request, &result);
@@ -286,16 +293,20 @@ TEST_F(TaskManagerGRPCServiceTest, shouldAddLabel)
     auto labels = tasks[0].data().labels();
     ASSERT_EQ(2, labels.size());
     EXPECT_EQ(task_.labels(0), labels[0]);
-    EXPECT_EQ(new_label, labels[1].str());
+    EXPECT_EQ(new_label, labels[1]);
 }
 
 TEST_F(TaskManagerGRPCServiceTest, shouldFailToAddLabelWithInvalidID)
 {
     grpc::ServerContext context;
     Transfer::IDWithLabel request;
-    request.mutable_id()->set_value(id_.value()+1);
-    std::string new_label = "new_label";
-    request.mutable_label()->set_str(new_label);
+    auto id = std::make_unique<Core::TaskID>(id_);
+    id->set_value(id->value()+1);
+    request.set_allocated_id(id.release());
+    std::string new_label_str = "new_label";
+    Core::Label new_label;
+    new_label.set_str(new_label_str);
+    request.set_allocated_label(std::make_unique<Core::Label>(new_label).release());
     Core::ModelRequestResult result;
 
     grpc::Status status = service_->AddLabel(&context, &request, &result);
@@ -314,9 +325,9 @@ TEST_F(TaskManagerGRPCServiceTest, shouldRemoveLabel)
 {
     grpc::ServerContext context;
     Transfer::IDWithLabel request;
-    request.mutable_id()->CopyFrom(id_);
+    request.set_allocated_id(std::make_unique<Core::TaskID>(id_).release());
     auto label_to_remove = task_.labels(0);
-    request.mutable_label()->CopyFrom(label_to_remove);
+    request.set_allocated_label(std::make_unique<Core::Label>(label_to_remove).release());
     Core::ModelRequestResult result;
 
     grpc::Status status = service_->RemoveLabel(&context, &request, &result);
@@ -334,9 +345,11 @@ TEST_F(TaskManagerGRPCServiceTest, shouldFailToRemoveLabelWithInvalidID)
 {
     grpc::ServerContext context;
     Transfer::IDWithLabel request;
-    request.mutable_id()->set_value(id_.value()+1);
+    auto id = std::make_unique<Core::TaskID>(id_);
+    id->set_value(id->value()+1);
+    request.set_allocated_id(id.release());
     auto label_to_remove = task_.labels(0);
-    request.mutable_label()->CopyFrom(label_to_remove);
+    request.set_allocated_label(std::make_unique<Core::Label>(label_to_remove).release());
     Core::ModelRequestResult result;
 
     grpc::Status status = service_->RemoveLabel(&context, &request, &result);
@@ -355,9 +368,10 @@ TEST_F(TaskManagerGRPCServiceTest, shouldFailToRemoveLabelWrongLabel)
 {
     grpc::ServerContext context;
     Transfer::IDWithLabel request;
-    request.mutable_id()->CopyFrom(id_);
-    std::string label_to_remove = "missing";
-    request.mutable_label()->set_str(label_to_remove);
+    request.set_allocated_id(std::make_unique<Core::TaskID>(id_).release());
+    Core::Label label_to_remove;
+    label_to_remove.set_str("missing");
+    request.set_allocated_label(std::make_unique<Core::Label>(label_to_remove).release());
     Core::ModelRequestResult result;
 
     grpc::Status status = service_->RemoveLabel(&context, &request, &result);
@@ -376,9 +390,10 @@ TEST_F(TaskManagerGRPCServiceTest, shouldRemoveAllLabels)
 {
     grpc::ServerContext context;
     Transfer::IDWithLabel request1;
-    request1.mutable_id()->CopyFrom(id_);
-    std::string new_label = "new_label";
-    request1.mutable_label()->set_str(new_label);
+    request1.set_allocated_id(std::make_unique<Core::TaskID>(id_).release());
+    Core::Label new_label;
+    new_label.set_str("new_label");
+    request1.set_allocated_label(std::make_unique<Core::Label>(new_label).release());
     Core::ModelRequestResult result;
 
     service_->AddLabel(&context, &request1, &result);
@@ -402,9 +417,10 @@ TEST_F(TaskManagerGRPCServiceTest, shouldFailToRemoveAllLabelsWithWrongID)
 {
     grpc::ServerContext context;
     Transfer::IDWithLabel request1;
-    request1.mutable_id()->CopyFrom(id_);
-    std::string new_label = "new_label";
-    request1.mutable_label()->set_str(new_label);
+    request1.set_allocated_id(std::make_unique<Core::TaskID>(id_).release());
+    Core::Label new_label;
+    new_label.set_str("new_label");
+    request1.set_allocated_label(std::make_unique<Core::Label>(new_label).release());
     Core::ModelRequestResult result;
 
     service_->AddLabel(&context, &request1, &result);
@@ -427,10 +443,11 @@ TEST_F(TaskManagerGRPCServiceTest, shouldFailToRemoveAllLabelsWithWrongID)
 TEST_F(TaskManagerGRPCServiceTest, shouldReplaceAllTasks)
 {
     Core::TaskEntity te;
-    te.mutable_data()->CopyFrom(task_);
-    std::string new_title = "new";
-    te.mutable_data()->set_title(new_title);
-    te.mutable_id()->CopyFrom(id_);
+    auto task = std::make_unique<Core::Task>(task_);
+    std::string new_title{"new"};
+    task->set_title(new_title);
+    te.set_allocated_data(task.release());
+    te.set_allocated_id(std::make_unique<Core::TaskID>(id_).release());
 
     Transfer::ManyTaskEntities request;
     request.mutable_tasks()->Add(std::move(te));

--- a/test/ui/ActionTest.cpp
+++ b/test/ui/ActionTest.cpp
@@ -58,7 +58,7 @@ public:
 TEST_F(ActionTest, shouldAddTask)
 {
     ASSERT_EQ(1, tm_->getTasks().size());
-    EXPECT_TRUE(ToBool(tm_->IsPresent(id_)));
+    EXPECT_TRUE(ToBool(tm_->CheckTask(id_)));
 }
 
 TEST_F(ActionTest, shouldAddSubtask)
@@ -70,7 +70,7 @@ TEST_F(ActionTest, shouldAddSubtask)
     ActionResult result_subtask = subact.execute(tm_);
     ASSERT_EQ(2, tm_->getTasks().size());
     ASSERT_TRUE(result_subtask.model_result);
-    auto check = tm_->IsPresent(result_subtask.model_result->id());
+    auto check = tm_->CheckTask(result_subtask.model_result->id());
     ASSERT_TRUE(check.has_id());
     EXPECT_NE(id_, result_subtask.model_result->id());
 
@@ -134,7 +134,7 @@ TEST_F(ActionTest, shouldEditTask)
     ActionResult result_edit = act.execute(tm_);
 
     ASSERT_EQ(1, tm_->getTasks().size());
-    EXPECT_TRUE(ToBool(tm_->IsPresent(id_)));
+    EXPECT_TRUE(ToBool(tm_->CheckTask(id_)));
 
     ASSERT_TRUE(result_edit.model_result);
     ASSERT_TRUE(result_edit.model_result->has_id());

--- a/test/ui/IntegrationTest.cpp
+++ b/test/ui/IntegrationTest.cpp
@@ -95,17 +95,17 @@ TEST_F(IntegrationTest, shouldCreateThreeTasksCompleteOneDeleteOne)
 
     Core::TaskID id;
     id.set_value(1);
-    ASSERT_TRUE(ToBool(tm->IsPresent(id)));
+    ASSERT_TRUE(ToBool(tm->CheckTask(id)));
     EXPECT_EQ(tm->getTasks()[0].id(), id);
     EXPECT_TRUE(tm->getTasks()[0].data().is_complete());
 
     id.set_value(2);
-    ASSERT_TRUE(ToBool(tm->IsPresent(id)));
+    ASSERT_TRUE(ToBool(tm->CheckTask(id)));
     EXPECT_EQ(tm->getTasks()[1].id(), id);
     EXPECT_FALSE(tm->getTasks()[1].data().is_complete());
 
     id.set_value(3);
-    EXPECT_FALSE(ToBool(tm->IsPresent(id)));
+    EXPECT_FALSE(ToBool(tm->CheckTask(id)));
 
     EXPECT_EQ(4, tm->gen()->state());
 }
@@ -144,19 +144,19 @@ TEST_F(IntegrationTest, shouldCreateTaskWithSubtasksCompleteAll)
     // check completeness
     Core::TaskID id;
     id.set_value(1);
-    ASSERT_TRUE(ToBool(tm->IsPresent(id)));
+    ASSERT_TRUE(ToBool(tm->CheckTask(id)));
     EXPECT_EQ(tm->getTasks()[0].id(), id);
     EXPECT_TRUE(tm->getTasks()[0].data().is_complete());
 
     Core::TaskID id2;
     id2.set_value(2);
-    ASSERT_TRUE(ToBool(tm->IsPresent(id2)));
+    ASSERT_TRUE(ToBool(tm->CheckTask(id2)));
     EXPECT_EQ(tm->getTasks()[1].id(), id2);
     EXPECT_TRUE(tm->getTasks()[1].data().is_complete());
 
     Core::TaskID id3;
     id3.set_value(3);
-    ASSERT_TRUE(ToBool(tm->IsPresent(id3)));
+    ASSERT_TRUE(ToBool(tm->CheckTask(id3)));
     EXPECT_EQ(tm->getTasks()[2].id(), id3);
     EXPECT_TRUE(tm->getTasks()[2].data().is_complete());
 
@@ -207,18 +207,18 @@ TEST_F(IntegrationTest, shouldCreateTaskWithSubtasksLabelTwo)
     // check labels
     Core::TaskID id;
     id.set_value(1);
-    ASSERT_TRUE(ToBool(tm->IsPresent(id)));
+    ASSERT_TRUE(ToBool(tm->CheckTask(id)));
     EXPECT_TRUE(tasks[0].data().labels().empty());
 
     Core::TaskID id2;
     id2.set_value(2);
-    ASSERT_TRUE(ToBool(tm->IsPresent(id2)));
+    ASSERT_TRUE(ToBool(tm->CheckTask(id2)));
     EXPECT_EQ(1, tasks[1].data().labels().size());
     EXPECT_EQ("l2", tasks[1].data().labels()[0].str());
 
     Core::TaskID id3;
     id3.set_value(3);
-    ASSERT_TRUE(ToBool(tm->IsPresent(id3)));
+    ASSERT_TRUE(ToBool(tm->CheckTask(id3)));
     EXPECT_EQ(1, tasks[2].data().labels().size());
     EXPECT_EQ("l3", tasks[2].data().labels()[0].str());
 
@@ -263,11 +263,11 @@ TEST_F(IntegrationTest, shouldCreateThreeTasksDeleteTwoWithConfirm)
 
     Core::TaskID id;
     id.set_value(1);
-    ASSERT_FALSE(ToBool(tm->IsPresent(id)));
+    ASSERT_FALSE(ToBool(tm->CheckTask(id)));
     id.set_value(2);
-    ASSERT_TRUE(ToBool(tm->IsPresent(id)));
+    ASSERT_TRUE(ToBool(tm->CheckTask(id)));
     id.set_value(3);
-    ASSERT_FALSE(ToBool(tm->IsPresent(id)));
+    ASSERT_FALSE(ToBool(tm->CheckTask(id)));
 
     for (int i = 0; i <  prompts.size(); ++i) {
         EXPECT_EQ(prompts[i], prompts_expected[i]);
@@ -315,7 +315,7 @@ TEST_F(IntegrationTest, shouldCreateTaskWithBadInputs)
 
     Core::TaskID id;
     id.set_value(1);
-    EXPECT_TRUE(ToBool(tm->IsPresent(id)));
+    EXPECT_TRUE(ToBool(tm->CheckTask(id)));
 
     for (int i = 0; i <  prompts.size(); ++i) {
         EXPECT_EQ(prompts[i], prompts_expected[i]);
@@ -396,17 +396,17 @@ TEST_F(IntegrationTest, shouldCreateThreeTasksInAHeirarcySaveAndLoad)
     id2.set_value(2);
     id3.set_value(3);
 
-    ASSERT_TRUE(ToBool(tm->IsPresent(id1)));
+    ASSERT_TRUE(ToBool(tm->CheckTask(id1)));
     EXPECT_TRUE(tm->getTasks()[0].data().is_complete());
     EXPECT_EQ(tm->getTasks()[0].data().title(), "Task 1");
     EXPECT_FALSE(tm->getTasks()[0].has_parent());
 
-    ASSERT_TRUE(ToBool(tm->IsPresent(id2)));
+    ASSERT_TRUE(ToBool(tm->CheckTask(id2)));
     EXPECT_TRUE(tm->getTasks()[1].data().is_complete());
     EXPECT_EQ(tm->getTasks()[1].data().title(), "Subtask 2");
     EXPECT_EQ(id1, tm->getTasks()[1].parent());
 
-    ASSERT_TRUE(ToBool(tm->IsPresent(id3)));
+    ASSERT_TRUE(ToBool(tm->CheckTask(id3)));
     EXPECT_TRUE(tm->getTasks()[2].data().is_complete());
     EXPECT_EQ(tm->getTasks()[2].data().title(), "Subtask 3");
     EXPECT_EQ(id2, tm->getTasks()[2].parent());


### PR DESCRIPTION
In the API, IsPresent() was confusing, as it is usually expected that functions with prefix is- in their name return a bool. However, IsPresent() returned Core::ModelRequestResult. Renaming the function, instead of changing API was easier and made more sense