### PR TITLE
changed mutable to set_allocated for protobuf structures

### DIFF
--- a/src/model/TaskManager.cpp
+++ b/src/model/TaskManager.cpp
@@ -137,7 +137,7 @@ std::vector<Core::TaskEntity> TaskManager::getTaskWithSubtasks(const Core::TaskI
         for (const auto &ch_id: ChildrenOf(id)) {
             auto ch_tasks = getTaskWithSubtasks(ch_id);
             for (auto &ch_task: ch_tasks) {
-                ch_task.mutable_parent()->CopyFrom(*ParentOf(ch_task.id()));
+                ch_task.set_allocated_parent(std::make_unique<Core::TaskID>(*ParentOf(ch_task.id())).release());
             }
             tasks.insert(tasks.end(), ch_tasks.begin(), ch_tasks.end());
         }

--- a/src/transport/TaskManagerGRPCClient.cpp
+++ b/src/transport/TaskManagerGRPCClient.cpp
@@ -51,8 +51,8 @@ Core::ModelRequestResult TaskManagerGRPCClient::Add(const Core::Task& request) {
 
 Core::ModelRequestResult TaskManagerGRPCClient::AddSubtask(const Core::Task& task, const Core::TaskID &id) {
     Core::TaskEntity request;
-    request.mutable_id()->CopyFrom(id);
-    request.mutable_data()->CopyFrom(task);
+    request.set_allocated_id(std::make_unique<Core::TaskID>(id).release());
+    request.set_allocated_data(std::make_unique<Core::Task>(task).release());
     Core::ModelRequestResult reply;
     grpc::ClientContext context;
     grpc::Status status = stub_->AddSubtask(&context, request, &reply);
@@ -62,8 +62,8 @@ Core::ModelRequestResult TaskManagerGRPCClient::AddSubtask(const Core::Task& tas
 
 Core::ModelRequestResult TaskManagerGRPCClient::Edit(const Core::TaskID &id, const Core::Task& task) {
     Core::TaskEntity request;
-    request.mutable_id()->CopyFrom(id);
-    request.mutable_data()->CopyFrom(task);
+    request.set_allocated_id(std::make_unique<Core::TaskID>(id).release());
+    request.set_allocated_data(std::make_unique<Core::Task>(task).release());
     Core::ModelRequestResult reply;
     grpc::ClientContext context;
     grpc::Status status = stub_->Edit(&context, request, &reply);
@@ -105,8 +105,8 @@ Core::ModelRequestResult TaskManagerGRPCClient::CheckTask(const Core::TaskID &re
 
 Core::ModelRequestResult TaskManagerGRPCClient::AddLabel(const Core::TaskID &id, const Core::Label &label) {
     Transfer::IDWithLabel request;
-    request.mutable_id()->CopyFrom(id);
-    request.mutable_label()->CopyFrom(label);
+    request.set_allocated_id(std::make_unique<Core::TaskID>(id).release());
+    request.set_allocated_label(std::make_unique<Core::Label>(label).release());
     Core::ModelRequestResult reply;
     grpc::ClientContext context;
     grpc::Status status = stub_->AddLabel(&context, request, &reply);
@@ -116,8 +116,8 @@ Core::ModelRequestResult TaskManagerGRPCClient::AddLabel(const Core::TaskID &id,
 
 Core::ModelRequestResult TaskManagerGRPCClient::RemoveLabel(const Core::TaskID &id, const Core::Label &label) {
     Transfer::IDWithLabel request;
-    request.mutable_id()->CopyFrom(id);
-    request.mutable_label()->CopyFrom(label);
+    request.set_allocated_id(std::make_unique<Core::TaskID>(id).release());
+    request.set_allocated_label(std::make_unique<Core::Label>(label).release());
     Core::ModelRequestResult reply;
     grpc::ClientContext context;
     grpc::Status status = stub_->RemoveLabel(&context, request, &reply);

--- a/src/utilities/TaskEntityUtils.cpp
+++ b/src/utilities/TaskEntityUtils.cpp
@@ -18,15 +18,15 @@ Core::TaskEntity  Core::createTaskEntity(const Core::TaskID &id,
                                         const Core::Task &task,
                                         const Core::TaskID &parent_id) {
     Core::TaskEntity te;
-    te.mutable_id()->CopyFrom(id);
-    te.mutable_data()->CopyFrom(task);
-    te.mutable_parent()->CopyFrom(parent_id);
+    te.set_allocated_id(std::make_unique<Core::TaskID>(id).release());
+    te.set_allocated_data(std::make_unique<Core::Task>(task).release());
+    te.set_allocated_parent(std::make_unique<Core::TaskID>(parent_id).release());
     return te;
 }
 Core::TaskEntity  Core::createTaskEntity(const Core::TaskID &id,
                                          const Core::Task &task) {
     Core::TaskEntity te;
-    te.mutable_id()->CopyFrom(id);
-    te.mutable_data()->CopyFrom(task);
+    te.set_allocated_id(std::make_unique<Core::TaskID>(id).release());
+    te.set_allocated_data(std::make_unique<Core::Task>(task).release());
     return te;
 }

--- a/test/transfer/TaskManagerClinetTest.cpp
+++ b/test/transfer/TaskManagerClinetTest.cpp
@@ -41,8 +41,8 @@ public:
                                  false);
         task_.set_is_complete(false);
         id_.set_value(42);
-        entity_.mutable_id()->CopyFrom(id_);
-        entity_.mutable_data()->CopyFrom(task_);
+        entity_.set_allocated_id(std::make_unique<Core::TaskID>(id_).release());
+        entity_.set_allocated_data(std::make_unique<Core::Task>(task_).release());
     }
 };
 
@@ -244,10 +244,10 @@ TEST_F(TaskManagerGRPCClientTest, shouldSendAddLabelRequest)
 {
     auto stub = std::make_unique<MockTaskManagerStub>();
     IDWithLabel request;
-    request.mutable_id()->CopyFrom(id_);
+    request.set_allocated_id(std::make_unique<Core::TaskID>(id_).release());
     Core::Label new_label;
     new_label.set_str("new_label");
-    request.mutable_label()->CopyFrom(new_label);
+    request.set_allocated_label(std::make_unique<Core::Label>(new_label).release());
 
     EXPECT_CALL(*stub, AddLabel(_, request, _))
             .WillOnce(testing::Invoke(
@@ -266,10 +266,10 @@ TEST_F(TaskManagerGRPCClientTest, shouldSendRemoveLabelRequest)
 {
     auto stub = std::make_unique<MockTaskManagerStub>();
     IDWithLabel request;
-    request.mutable_id()->CopyFrom(id_);
+    request.set_allocated_id(std::make_unique<Core::TaskID>(id_).release());
     Core::Label label;
     label.set_str("label");
-    request.mutable_label()->CopyFrom(label);
+    request.set_allocated_label(std::make_unique<Core::Label>(label).release());
 
     EXPECT_CALL(*stub, RemoveLabel(_, request, _))
             .WillOnce(testing::Invoke(

--- a/test/transfer/TaskManagerServiceTest.cpp
+++ b/test/transfer/TaskManagerServiceTest.cpp
@@ -97,8 +97,8 @@ TEST_F(TaskManagerGRPCServiceTest, shouldAddSubtask)
 {
     grpc::ServerContext context;
     Core::TaskEntity request;
-    request.mutable_data()->CopyFrom(task_);
-    request.mutable_id()->CopyFrom(id_);
+    request.set_allocated_id(std::make_unique<Core::TaskID>(id_).release());
+    request.set_allocated_data(std::make_unique<Core::Task>(task_).release());
     Core::ModelRequestResult result;
     grpc::Status status = service_->AddSubtask(&context, &request, &result);
     ASSERT_TRUE(status.ok());
@@ -115,10 +115,12 @@ TEST_F(TaskManagerGRPCServiceTest, shouldEditTask)
 {
     grpc::ServerContext context;
     Core::TaskEntity request;
-    request.mutable_data()->CopyFrom(task_);
+
+    request.set_allocated_id(std::make_unique<Core::TaskID>(id_).release());
     std::string new_title = "edited";
-    request.mutable_data()->set_title(new_title);
-    request.mutable_id()->CopyFrom(id_);
+    auto task = std::make_unique<Core::Task>(task_);
+    task->set_title(new_title);
+    request.set_allocated_data(task.release());
     Core::ModelRequestResult result;
     grpc::Status status = service_->Edit(&context, &request, &result);
     ASSERT_TRUE(status.ok());
@@ -133,10 +135,13 @@ TEST_F(TaskManagerGRPCServiceTest, shouldFailToEditTaskWithWrongID)
 {
     grpc::ServerContext context;
     Core::TaskEntity request;
-    request.mutable_data()->CopyFrom(task_);
+    auto id = std::make_unique<Core::TaskID>(id_);
+    id->set_value(id->value()+1);
+    request.set_allocated_id(id.release());
     std::string new_title = "edited";
-    request.mutable_data()->set_title(new_title);
-    request.mutable_id()->set_value(id_.value()+1);
+    auto task = std::make_unique<Core::Task>(task_);
+    task->set_title(new_title);
+    request.set_allocated_data(task.release());
     Core::ModelRequestResult result;
     grpc::Status status = service_->Edit(&context, &request, &result);
     ASSERT_TRUE(status.ok());
@@ -213,8 +218,8 @@ TEST_F(TaskManagerGRPCServiceTest, shouldDeleteTaskWithSubtasks)
 {
     grpc::ServerContext context;
     Core::TaskEntity request1;
-    request1.mutable_id()->CopyFrom(id_);
-    request1.mutable_data()->CopyFrom(task_);
+    request1.set_allocated_id(std::make_unique<Core::TaskID>(id_).release());
+    request1.set_allocated_data(std::make_unique<Core::Task>(task_).release());
     Core::ModelRequestResult result;
     service_->AddSubtask(&context, &request1, &result);
 
@@ -271,9 +276,11 @@ TEST_F(TaskManagerGRPCServiceTest, shouldAddLabel)
 {
     grpc::ServerContext context;
     Transfer::IDWithLabel request;
-    request.mutable_id()->CopyFrom(id_);
-    std::string new_label = "new_label";
-    request.mutable_label()->set_str(new_label);
+    request.set_allocated_id(std::make_unique<Core::TaskID>(id_).release());
+    std::string new_label_str = "new_label";
+    Core::Label new_label;
+    new_label.set_str(new_label_str);
+    request.set_allocated_label(std::make_unique<Core::Label>(new_label).release());
     Core::ModelRequestResult result;
 
     grpc::Status status = service_->AddLabel(&context, &request, &result);
@@ -286,16 +293,20 @@ TEST_F(TaskManagerGRPCServiceTest, shouldAddLabel)
     auto labels = tasks[0].data().labels();
     ASSERT_EQ(2, labels.size());
     EXPECT_EQ(task_.labels(0), labels[0]);
-    EXPECT_EQ(new_label, labels[1].str());
+    EXPECT_EQ(new_label, labels[1]);
 }
 
 TEST_F(TaskManagerGRPCServiceTest, shouldFailToAddLabelWithInvalidID)
 {
     grpc::ServerContext context;
     Transfer::IDWithLabel request;
-    request.mutable_id()->set_value(id_.value()+1);
-    std::string new_label = "new_label";
-    request.mutable_label()->set_str(new_label);
+    auto id = std::make_unique<Core::TaskID>(id_);
+    id->set_value(id->value()+1);
+    request.set_allocated_id(id.release());
+    std::string new_label_str = "new_label";
+    Core::Label new_label;
+    new_label.set_str(new_label_str);
+    request.set_allocated_label(std::make_unique<Core::Label>(new_label).release());
     Core::ModelRequestResult result;
 
     grpc::Status status = service_->AddLabel(&context, &request, &result);
@@ -314,9 +325,9 @@ TEST_F(TaskManagerGRPCServiceTest, shouldRemoveLabel)
 {
     grpc::ServerContext context;
     Transfer::IDWithLabel request;
-    request.mutable_id()->CopyFrom(id_);
+    request.set_allocated_id(std::make_unique<Core::TaskID>(id_).release());
     auto label_to_remove = task_.labels(0);
-    request.mutable_label()->CopyFrom(label_to_remove);
+    request.set_allocated_label(std::make_unique<Core::Label>(label_to_remove).release());
     Core::ModelRequestResult result;
 
     grpc::Status status = service_->RemoveLabel(&context, &request, &result);
@@ -334,9 +345,11 @@ TEST_F(TaskManagerGRPCServiceTest, shouldFailToRemoveLabelWithInvalidID)
 {
     grpc::ServerContext context;
     Transfer::IDWithLabel request;
-    request.mutable_id()->set_value(id_.value()+1);
+    auto id = std::make_unique<Core::TaskID>(id_);
+    id->set_value(id->value()+1);
+    request.set_allocated_id(id.release());
     auto label_to_remove = task_.labels(0);
-    request.mutable_label()->CopyFrom(label_to_remove);
+    request.set_allocated_label(std::make_unique<Core::Label>(label_to_remove).release());
     Core::ModelRequestResult result;
 
     grpc::Status status = service_->RemoveLabel(&context, &request, &result);
@@ -355,9 +368,10 @@ TEST_F(TaskManagerGRPCServiceTest, shouldFailToRemoveLabelWrongLabel)
 {
     grpc::ServerContext context;
     Transfer::IDWithLabel request;
-    request.mutable_id()->CopyFrom(id_);
-    std::string label_to_remove = "missing";
-    request.mutable_label()->set_str(label_to_remove);
+    request.set_allocated_id(std::make_unique<Core::TaskID>(id_).release());
+    Core::Label label_to_remove;
+    label_to_remove.set_str("missing");
+    request.set_allocated_label(std::make_unique<Core::Label>(label_to_remove).release());
     Core::ModelRequestResult result;
 
     grpc::Status status = service_->RemoveLabel(&context, &request, &result);
@@ -376,9 +390,10 @@ TEST_F(TaskManagerGRPCServiceTest, shouldRemoveAllLabels)
 {
     grpc::ServerContext context;
     Transfer::IDWithLabel request1;
-    request1.mutable_id()->CopyFrom(id_);
-    std::string new_label = "new_label";
-    request1.mutable_label()->set_str(new_label);
+    request1.set_allocated_id(std::make_unique<Core::TaskID>(id_).release());
+    Core::Label new_label;
+    new_label.set_str("new_label");
+    request1.set_allocated_label(std::make_unique<Core::Label>(new_label).release());
     Core::ModelRequestResult result;
 
     service_->AddLabel(&context, &request1, &result);
@@ -402,9 +417,10 @@ TEST_F(TaskManagerGRPCServiceTest, shouldFailToRemoveAllLabelsWithWrongID)
 {
     grpc::ServerContext context;
     Transfer::IDWithLabel request1;
-    request1.mutable_id()->CopyFrom(id_);
-    std::string new_label = "new_label";
-    request1.mutable_label()->set_str(new_label);
+    request1.set_allocated_id(std::make_unique<Core::TaskID>(id_).release());
+    Core::Label new_label;
+    new_label.set_str("new_label");
+    request1.set_allocated_label(std::make_unique<Core::Label>(new_label).release());
     Core::ModelRequestResult result;
 
     service_->AddLabel(&context, &request1, &result);
@@ -427,10 +443,11 @@ TEST_F(TaskManagerGRPCServiceTest, shouldFailToRemoveAllLabelsWithWrongID)
 TEST_F(TaskManagerGRPCServiceTest, shouldReplaceAllTasks)
 {
     Core::TaskEntity te;
-    te.mutable_data()->CopyFrom(task_);
-    std::string new_title = "new";
-    te.mutable_data()->set_title(new_title);
-    te.mutable_id()->CopyFrom(id_);
+    auto task = std::make_unique<Core::Task>(task_);
+    std::string new_title{"new"};
+    task->set_title(new_title);
+    te.set_allocated_data(task.release());
+    te.set_allocated_id(std::make_unique<Core::TaskID>(id_).release());
 
     Transfer::ManyTaskEntities request;
     request.mutable_tasks()->Add(std::move(te));


### PR DESCRIPTION
Changed mutable to set_allocated for protobuf structures where possible, repeated fields still use mutable and AddAllocated